### PR TITLE
feat: add ClearAvatarsCommand to clear generated letter avatars

### DIFF
--- a/Classes/AvatarProvider/LetterAvatarProvider.php
+++ b/Classes/AvatarProvider/LetterAvatarProvider.php
@@ -9,11 +9,10 @@ use KonradMichalik\Typo3LetterAvatar\Enum\ImageFormat;
 use KonradMichalik\Typo3LetterAvatar\Enum\Transform;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 use KonradMichalik\Typo3LetterAvatar\Utility\ImageDriverUtility;
+use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
 use TYPO3\CMS\Backend\Backend\Avatar\AvatarProviderInterface;
 use TYPO3\CMS\Backend\Backend\Avatar\Image;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\PathUtility;
 
 class LetterAvatarProvider implements AvatarProviderInterface
 {
@@ -37,7 +36,7 @@ class LetterAvatarProvider implements AvatarProviderInterface
         );
 
         $fileName = $avatarService->configToHash() . '.' . $imageFormat->value;
-        $filePath = $this->getImageFolder() . $fileName;
+        $filePath = PathUtility::getImageFolder() . $fileName;
 
         if (!file_exists($filePath)) {
             $avatarService->saveAs($filePath);
@@ -45,26 +44,11 @@ class LetterAvatarProvider implements AvatarProviderInterface
 
         return GeneralUtility::makeInstance(
             Image::class,
-            $this->getWebPath($fileName),
+            PathUtility::getWebPath($fileName),
             ConfigurationUtility::get('size'),
             ConfigurationUtility::get('size'),
         );
     }
-
-    private function getImageFolder(): string
-    {
-        $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
-        if (!is_dir($folder)) {
-            GeneralUtility::mkdir_deep($folder);
-        }
-        return $folder;
-    }
-
-    private function getWebPath(string $filename): string
-    {
-        return PathUtility::getAbsoluteWebPath(ConfigurationUtility::get('imagePath') . $filename);
-    }
-
     private function getName(array $backendUser): string
     {
         return ConfigurationUtility::get('prioritizeRealName') ?

--- a/Classes/Command/ClearAvatarsCommand.php
+++ b/Classes/Command/ClearAvatarsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Command;
+
+use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class ClearAvatarsCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setHelp('Clear all generated letter avatars.')
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Simulate the deletion process without actually deleting files.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = PathUtility::getImageFolder();
+        $output->writeln("🧽 - Clearing all generated letter avatars in <question>$path</question>");
+
+        $imageCount = 0;
+        if (is_dir($path)) {
+            $files = scandir($path);
+            $imageCount = count(array_filter($files, function ($file) use ($path) {
+                return is_file($path . DIRECTORY_SEPARATOR . $file) && preg_match('/\.(png|jpg|jpeg)$/i', $file);
+            }));
+        }
+
+        if ($input->getOption('dry-run')) {
+            $output->writeln("ℹ️ - <comment>$imageCount</comment> letter avatars would be cleared (dry-run).");
+            return Command::SUCCESS;
+        }
+
+        $return = GeneralUtility::rmdir($path, true);
+
+        if ($return === false) {
+            $output->writeln('❌ - Failed to clear generated letter avatars.');
+            return Command::FAILURE;
+        }
+
+        $output->writeln("✅  - <comment>$imageCount</comment> letter avatars have been cleared.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Utility;
+
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PathUtility
+{
+    public static function getImageFolder(): string
+    {
+        $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
+        if (!is_dir($folder)) {
+            GeneralUtility::mkdir_deep($folder);
+        }
+        return $folder;
+    }
+
+    public static function getWebPath(string $filename): string
+    {
+        return \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(ConfigurationUtility::get('imagePath') . $filename);
+    }
+}

--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -12,6 +12,11 @@ class PathUtility
     public static function getImageFolder(): string
     {
         $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
+
+        if (!str_ends_with($folder, '/')) {
+            $folder .= '/';
+        }
+
         if (!is_dir($folder)) {
             GeneralUtility::mkdir_deep($folder);
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,3 +7,9 @@ services:
     KonradMichalik\Typo3LetterAvatar\:
         resource: '../Classes/*'
         exclude: '../Classes/Domain/Model/*'
+
+    KonradMichalik\Typo3LetterAvatar\Command\ClearAvatarsCommand:
+        tags:
+            - name: console.command
+              command: 'avatar:clear'
+              description: 'Clear all generated letter avatars.'

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ KonradMichalik\Typo3LetterAvatar\Utility\ImageDriverUtility::resolveAvatarServic
 )->saveAs('path/to/file.png');
 ```
 
+## Command
+
+Clear all generated avatar images with the following command:
+
+```bash
+vendor/bin/typo3 avatar:clear
+```
+
 ## Development
 
 Use the following ddev command to easily install all supported TYPO3 versions for locale development.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a console command to clear all generated letter avatar images, with support for a dry-run mode.
- **Documentation**
  - Added instructions in the README on how to use the new command-line tool for clearing avatar images.
- **Refactor**
  - Centralized image path handling into a new utility, simplifying avatar image management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->