### PR TITLE
feat: add image driver gd

### DIFF
--- a/Classes/AvatarProvider/LetterAvatarProvider.php
+++ b/Classes/AvatarProvider/LetterAvatarProvider.php
@@ -9,11 +9,10 @@ use KonradMichalik\Typo3LetterAvatar\Enum\ImageFormat;
 use KonradMichalik\Typo3LetterAvatar\Enum\Transform;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 use KonradMichalik\Typo3LetterAvatar\Utility\ImageDriverUtility;
+use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
 use TYPO3\CMS\Backend\Backend\Avatar\AvatarProviderInterface;
 use TYPO3\CMS\Backend\Backend\Avatar\Image;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\PathUtility;
 
 class LetterAvatarProvider implements AvatarProviderInterface
 {
@@ -37,7 +36,7 @@ class LetterAvatarProvider implements AvatarProviderInterface
         );
 
         $fileName = $avatarService->configToHash() . '.' . $imageFormat->value;
-        $filePath = $this->getImageFolder() . $fileName;
+        $filePath = PathUtility::getImageFolder() . $fileName;
 
         if (!file_exists($filePath)) {
             $avatarService->saveAs($filePath);
@@ -45,26 +44,11 @@ class LetterAvatarProvider implements AvatarProviderInterface
 
         return GeneralUtility::makeInstance(
             Image::class,
-            $this->getWebPath($fileName),
+            PathUtility::getWebPath($fileName),
             ConfigurationUtility::get('size'),
             ConfigurationUtility::get('size'),
         );
     }
-
-    private function getImageFolder(): string
-    {
-        $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
-        if (!is_dir($folder)) {
-            GeneralUtility::mkdir_deep($folder);
-        }
-        return $folder;
-    }
-
-    private function getWebPath(string $filename): string
-    {
-        return PathUtility::getAbsoluteWebPath(ConfigurationUtility::get('imagePath') . $filename);
-    }
-
     private function getName(array $backendUser): string
     {
         return ConfigurationUtility::get('prioritizeRealName') ?

--- a/Classes/Command/ClearAvatarsCommand.php
+++ b/Classes/Command/ClearAvatarsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Command;
+
+use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class ClearAvatarsCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->setHelp('Clear all generated letter avatars.')
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Simulate the deletion process without actually deleting files.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = PathUtility::getImageFolder();
+        $output->writeln("🧽 - Clearing all generated letter avatars in <question>$path</question>");
+
+        $imageCount = 0;
+        if (is_dir($path)) {
+            $files = scandir($path);
+            $imageCount = count(array_filter($files, function ($file) use ($path) {
+                return is_file($path . DIRECTORY_SEPARATOR . $file) && preg_match('/\.(png|jpg|jpeg)$/i', $file);
+            }));
+        }
+
+        if ($input->getOption('dry-run')) {
+            $output->writeln("ℹ️ - <comment>$imageCount</comment> letter avatars would be cleared (dry-run).");
+            return Command::SUCCESS;
+        }
+
+        $return = GeneralUtility::rmdir($path, true);
+
+        if ($return === false) {
+            $output->writeln('❌ - Failed to clear generated letter avatars.');
+            return Command::FAILURE;
+        }
+
+        $output->writeln("✅  - <comment>$imageCount</comment> letter avatars have been cleared.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Image/Driver/GdAvatar.php
+++ b/Classes/Image/Driver/GdAvatar.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Image\Driver;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\ImageFormat;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use KonradMichalik\Typo3LetterAvatar\Image\LetterAvatarInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class GdAvatar extends AbstractImageProvider implements LetterAvatarInterface
+{
+    public function generate()
+    {
+        $nameInitials = $this->resolveInitials();
+        $backgroundColor = $this->resolveBackgroundColor();
+        $foregroundColor = $this->resolveForegroundColor();
+
+        $canvas = imagecreatetruecolor($this->size, $this->size);
+        imagesavealpha($canvas, true);
+        $transparent = imagecolorallocatealpha($canvas, 0, 0, 0, 127);
+        imagefill($canvas, 0, 0, $transparent);
+
+        [$bgR, $bgG, $bgB] = sscanf($backgroundColor, '#%02x%02x%02x');
+        $bgColor = imagecolorallocate($canvas, $bgR, $bgG, $bgB);
+        imagefilledellipse($canvas, $this->size / 2, $this->size / 2, $this->size, $this->size, $bgColor);
+
+        [$fgR, $fgG, $fgB] = sscanf($foregroundColor, '#%02x%02x%02x');
+        $fgColor = imagecolorallocate($canvas, $fgR, $fgG, $fgB);
+
+        $fontPath = GeneralUtility::getFileAbsFileName($this->fontPath);
+        $fontSize = $this->size * $this->fontSize;
+        $textBox = imagettfbbox($fontSize, 0, $fontPath, $nameInitials);
+        $textX = ($this->size - ($textBox[2] - $textBox[0])) / 2;
+        $textY = ($this->size - ($textBox[5] - $textBox[1])) / 2;
+        $textY += $fontSize / 2;
+        imagettftext($canvas, $fontSize, 0, (int)$textX, (int)$textY, $fgColor, $fontPath, $nameInitials);
+
+        return $canvas;
+    }
+
+    public function saveAs(string $path, ImageFormat $format = ImageFormat::PNG, int $quality = 90): bool
+    {
+        if (empty($path)) {
+            return false;
+        }
+
+        $image = $this->generate();
+
+        switch ($format) {
+            case ImageFormat::JPEG:
+                imagejpeg($image, $path, $quality);
+                break;
+            case ImageFormat::PNG:
+                imagepng($image, $path);
+                break;
+            default:
+                return false;
+        }
+
+        imagedestroy($image);
+        return true;
+    }
+}

--- a/Classes/Utility/ImageDriverUtility.php
+++ b/Classes/Utility/ImageDriverUtility.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace KonradMichalik\Typo3LetterAvatar\Utility;
 
 use KonradMichalik\Typo3LetterAvatar\Enum\ImageDriver;
+use KonradMichalik\Typo3LetterAvatar\Image\Driver\GdAvatar;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\ImagickAvatar;
 use KonradMichalik\Typo3LetterAvatar\Image\LetterAvatarInterface;
+use TYPO3\CMS\Core\Utility\Exception\NotImplementedMethodException;
 
 class ImageDriverUtility
 {
@@ -16,6 +18,10 @@ class ImageDriverUtility
             case ImageDriver::IMAGICK:
             default:
                 return new ImagickAvatar(...$args);
+            case ImageDriver::GD:
+                return new GdAvatar(...$args);
+            case ImageDriver::GMAGICK:
+                throw new NotImplementedMethodException();
         }
     }
 }

--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Utility;
+
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PathUtility
+{
+    public static function getImageFolder(): string
+    {
+        $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
+        if (!is_dir($folder)) {
+            GeneralUtility::mkdir_deep($folder);
+        }
+        return $folder;
+    }
+
+    public static function getWebPath(string $filename): string
+    {
+        return \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(ConfigurationUtility::get('imagePath') . $filename);
+    }
+}

--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -12,6 +12,11 @@ class PathUtility
     public static function getImageFolder(): string
     {
         $folder = Environment::getPublicPath() . ConfigurationUtility::get('imagePath');
+
+        if (!str_ends_with($folder, '/')) {
+            $folder .= '/';
+        }
+
         if (!is_dir($folder)) {
             GeneralUtility::mkdir_deep($folder);
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,3 +7,9 @@ services:
     KonradMichalik\Typo3LetterAvatar\:
         resource: '../Classes/*'
         exclude: '../Classes/Domain/Model/*'
+
+    KonradMichalik\Typo3LetterAvatar\Command\ClearAvatarsCommand:
+        tags:
+            - name: console.command
+              command: 'avatar:clear'
+              description: 'Clear all generated letter avatars.'

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ KonradMichalik\Typo3LetterAvatar\Utility\ImageDriverUtility::resolveAvatarServic
 )->saveAs('path/to/file.png');
 ```
 
+## Command
+
+Clear all generated avatar images with the following command:
+
+```bash
+vendor/bin/typo3 avatar:clear
+```
+
 ## Development
 
 Use the following ddev command to easily install all supported TYPO3 versions for locale development.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": "^8.1",
-		"typo3/cms-beuser": "^11.0 || ^12.0 || ^13.0"
+		"typo3/cms-core": "^11.0 || ^12.0 || ^13.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -31,7 +31,8 @@
 		"typo3/cms-lowlevel": "^11.0 || ^12.0 || ^13.0"
 	},
 	"suggest": {
-		"ext-imagick": ""
+		"ext-gd": "Image processing library for avatar generation",
+		"ext-imagick": "Image processing library for avatar generation"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,4 +1,4 @@
-# cat=general/enable/10; type=options[Imagick=imagick,GraphicsMagick=gmagick]; label=Image driver
+# cat=general/enable/10; type=options[Imagick=imagick,GraphicsMagick=gmagick,GD=gd]; label=Image driver
 imageDriver = imagick
 # cat=general/enable/20; type=options[Stringify=stringify,Random=random,Theme=theme,Pairs=pairs]; label=Color mode
 colorMode = stringify


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating letter avatars using the GD image driver.
  - Introduced a command-line tool to clear all generated letter avatar images, with optional dry-run mode.

- **Improvements**
  - Enhanced avatar image path handling for improved reliability and maintainability.
  - Updated configuration to allow selection of the GD image driver.

- **Documentation**
  - Added instructions for using the avatar clearing command in the README.
  - Updated configuration template to reflect new image driver option.

- **Chores**
  - Updated dependencies and suggestions to support broader TYPO3 core versions and recommend the GD extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->