### PR TITLE
feat: add image driver graphicsmagick

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,7 +10,8 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.6"
-webimage_extra_packages: ["php${DDEV_PHP_VERSION}-gmagick", libxml2-utils]
+webimage_extra_packages: [libxml2-utils]
+#webimage_extra_packages: ["php${DDEV_PHP_VERSION}-gmagick", libxml2-utils]
 use_dns_when_possible: true
 corepack_enable: false
 hooks:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,7 +10,7 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.6"
-webimage_extra_packages: [libxml2-utils]
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-gmagick", libxml2-utils]
 use_dns_when_possible: true
 corepack_enable: false
 hooks:

--- a/Classes/Enum/ImageDriver.php
+++ b/Classes/Enum/ImageDriver.php
@@ -6,8 +6,8 @@ namespace KonradMichalik\Typo3LetterAvatar\Enum;
 
 enum ImageDriver: string implements EnumInterface
 {
-    case IMAGICK = 'imagick';
-    case GMAGICK = 'gmagick';
+    case IMAGICK = 'ImageMagick';
+    case GMAGICK = 'GraphicsMagick';
 
     case GD = 'gd';
 }

--- a/Classes/Enum/ImageDriver.php
+++ b/Classes/Enum/ImageDriver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Enum;
 
-enum ImageDriver: string
+enum ImageDriver: string implements EnumInterface
 {
     case IMAGICK = 'imagick';
     case GMAGICK = 'gmagick';

--- a/Classes/Image/Avatar.php
+++ b/Classes/Image/Avatar.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Image;
 
+use KonradMichalik\Typo3LetterAvatar\Enum\EnumInterface;
 use KonradMichalik\Typo3LetterAvatar\Enum\ImageDriver;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\GdAvatar;
+use KonradMichalik\Typo3LetterAvatar\Image\Driver\GmagickAvatar;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\ImagickAvatar;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
-use TYPO3\CMS\Core\Utility\Exception\NotImplementedMethodException;
 
 class Avatar
 {
@@ -23,7 +24,7 @@ class Avatar
             case ImageDriver::GD:
                 return new GdAvatar(...$args);
             case ImageDriver::GMAGICK:
-                throw new NotImplementedMethodException();
+                return new GmagickAvatar(...$args);
         }
     }
 }

--- a/Classes/Image/Avatar.php
+++ b/Classes/Image/Avatar.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Image;
 
-use KonradMichalik\Typo3LetterAvatar\Enum\EnumInterface;
 use KonradMichalik\Typo3LetterAvatar\Enum\ImageDriver;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\GdAvatar;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\GmagickAvatar;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\ImagickAvatar;
-use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 
 class Avatar
 {
     public static function create(...$args): LetterAvatarInterface
     {
-        $imageDriver = $args['imageDriver'] ?? ConfigurationUtility::get('imageDriver', ImageDriver::class);
+        $imageDriver = $args['imageDriver'] ?? $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'];
 
         switch ($imageDriver) {
             case ImageDriver::IMAGICK:

--- a/Classes/Image/Driver/GmagickAvatar.php
+++ b/Classes/Image/Driver/GmagickAvatar.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\Image\Driver;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\ImageFormat;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use KonradMichalik\Typo3LetterAvatar\Image\LetterAvatarInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class GmagickAvatar extends AbstractImageProvider implements LetterAvatarInterface
+{
+    public function generate(): \Gmagick
+    {
+        $nameInitials = $this->resolveInitials();
+        $backgroundColor = $this->resolveBackgroundColor();
+        $foregroundColor = $this->resolveForegroundColor();
+
+        $canvas = new \Gmagick();
+        $canvas->newimage($this->size, $this->size, 'transparent');
+        $canvas->setimageformat($this->imageFormat->value);
+
+        $draw = new \GmagickDraw();
+        $draw->setfillcolor($backgroundColor);
+        $draw->ellipse($this->size / 2, $this->size / 2, $this->size / 2, $this->size / 2, 0, 360);
+        $canvas->drawimage($draw);
+
+        $draw->setfillcolor($foregroundColor);
+        $draw->setfont(GeneralUtility::getFileAbsFileName($this->fontPath));
+        $draw->setfontsize($this->size * $this->fontSize);
+
+        $metrics = $canvas->queryfontmetrics($draw, $nameInitials);
+        $textX = ($this->size - $metrics['textWidth']) / 2;
+        $textY = ($this->size + $metrics['textHeight']) / 2;
+
+        $draw->annotate($textX, $textY, $nameInitials);
+        $canvas->drawimage($draw);
+
+        return $canvas;
+    }
+
+    public function saveAs(string $path, ImageFormat $format = ImageFormat::PNG, int $quality = 90): bool
+    {
+        if (empty($path)) {
+            return false;
+        }
+
+        $image = $this->generate();
+        $image->setimageformat($format->value);
+
+        if ($format === ImageFormat::JPEG) {
+            $image->setcompressionquality($quality);
+        }
+
+        $image->write($path);
+        return true;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This extension generates colorful backend user avatars using name initials lette
 ## Requirements
 
 * TYPO3 >= 12.4 & PHP 8.1+
+* one of the following image driver:
+  * ImageMagick
+  * GraphicsMagick
+  * GD
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ This extension generates colorful backend user avatars using name initials lette
 ## Requirements
 
 * TYPO3 >= 12.4 & PHP 8.1+
-* one of the following image driver:
-  * ImageMagick
-  * GraphicsMagick
-  * GD
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 	},
 	"suggest": {
 		"ext-gd": "Image processing library for avatar generation",
+		"ext-gmagick": "Image processing library for avatar generation",
 		"ext-imagick": "Image processing library for avatar generation"
 	},
 	"autoload": {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,4 @@
-# cat=general/enable/10; type=options[Imagick=imagick,GraphicsMagick=gmagick,GD=gd]; label=Image driver
-imageDriver = imagick
-# cat=general/enable/20; type=options[Stringify=stringify,Random=random,Theme=theme,Pairs=pairs]; label=Color mode
+# cat=general/enable/10; type=options[Stringify=stringify,Random=random,Theme=theme,Pairs=pairs]; label=Color mode
 colorMode = stringify
-# cat=general/enable/30; type=options[Grayscale (light)=grayscale-light,Grayscale (dark)=grayscale-dark,Colorful=colorful,Pastel=pastel]; label=Theme
+# cat=general/enable/20; type=options[Grayscale (light)=grayscale-light,Grayscale (dark)=grayscale-dark,Colorful=colorful,Pastel=pastel]; label=Theme
 theme = colorful


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating avatars using the Gmagick image driver.
- **Improvements**
  - Updated image driver options to use more descriptive names for ImageMagick and GraphicsMagick.
  - Avatar creation now supports all three image drivers: GD, ImageMagick, and GraphicsMagick.
- **Configuration**
  - Simplified configuration template by removing the "Image driver" option and adjusting the order of remaining options.
  - Added a suggestion for the Gmagick PHP extension in the package recommendations.
- **Chores**
  - Added a commented example for Gmagick installation in the development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->