### PR TITLE
feat: add AvatarViewHelper for generating letter avatars in Fluid templates

### DIFF
--- a/Classes/AvatarProvider/LetterAvatarProvider.php
+++ b/Classes/AvatarProvider/LetterAvatarProvider.php
@@ -29,7 +29,6 @@ class LetterAvatarProvider implements AvatarProviderInterface
             throw new \InvalidArgumentException('Invalid color mode', 1204028706);
         }
 
-        $imageFormat = ConfigurationUtility::get('imageFormat', ImageFormat::class);
         $configuration = [
             'name' => $this->getName($backendUser),
             'mode' => $mode,
@@ -37,14 +36,14 @@ class LetterAvatarProvider implements AvatarProviderInterface
             'size' => ConfigurationUtility::get('size'),
             'fontSize' => ConfigurationUtility::get('fontSize'),
             'fontPath' => ConfigurationUtility::get('fontPath'),
-            'imageFormat' => $imageFormat,
+            'imageFormat' => ConfigurationUtility::get('imageFormat', ImageFormat::class),
             'transform' => ConfigurationUtility::get('transform', Transform::class),
         ];
 
         $this->eventDispatcher->dispatch(new BackendUserAvatarConfigurationEvent($backendUser, $configuration));
         $avatarService = Avatar::create(...$configuration);
 
-        $fileName = $avatarService->configToHash() . '.' . $imageFormat->value;
+        $fileName = $avatarService->configToHash() . '.' . $configuration['imageFormat']->value;
         $filePath = PathUtility::getImageFolder() . $fileName;
 
         if (!file_exists($filePath)) {

--- a/Classes/ViewHelpers/AvatarViewHelper.php
+++ b/Classes/ViewHelpers/AvatarViewHelper.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KonradMichalik\Typo3LetterAvatar\ViewHelpers;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\ColorMode;
+use KonradMichalik\Typo3LetterAvatar\Enum\ImageFormat;
+use KonradMichalik\Typo3LetterAvatar\Enum\Transform;
+use KonradMichalik\Typo3LetterAvatar\Image\Avatar;
+use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
+use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+* This ViewHelper generates the URL of an avatar image based on the provided configuration.
+* You can specify properties such as name, initials, size, font, colors and transformation.
+* If the avatar image does not already exist, it will be generated and saved.
+* Useful for generating letter avatars for TYPO3 frontend users.
+*
+* Example usage:
+* ```html
+* <html xmlns:letter="http://typo3.org/ns/KonradMichalik/Typo3LetterAvatar/ViewHelpers">
+*
+* <img src="{letter:avatar(name: 'John Doe')}" alt="Avatar of John Doe" />
+* ```
+*/
+class AvatarViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument(
+            'name',
+            'string',
+            'Name for the avatar',
+            false
+        );
+        $this->registerArgument(
+            'initials',
+            'string',
+            'Initials for the avatar',
+            false
+        );
+        $this->registerArgument(
+            'size',
+            'integer',
+            'Size of the avatar',
+            false
+        );
+        $this->registerArgument(
+            'fontSize',
+            'float',
+            'Font size of the avatar',
+            false
+        );
+        $this->registerArgument(
+            'fontPath',
+            'string',
+            'Path to the font file',
+            false
+        );
+        $this->registerArgument(
+            'foregroundColor',
+            'string',
+            'Foreground color of the avatar',
+            false
+        );
+        $this->registerArgument(
+            'backgroundColor',
+            'string',
+            'Background color of the avatar',
+            false
+        );
+        $this->registerArgument(
+            'mode',
+            'string',
+            'Color mode of the avatar (e.g., CUSTOM)',
+            false
+        );
+        $this->registerArgument(
+            'theme',
+            'string',
+            'Theme of the avatar',
+            false
+        );
+        $this->registerArgument(
+            'imageFormat',
+            'string',
+            'Image format of the avatar (e.g., PNG)',
+            false
+        );
+        $this->registerArgument(
+            'transform',
+            'string',
+            'Text transformation (e.g., NONE)',
+            false
+        );
+    }
+
+    public function render(): string
+    {
+        if (empty($this->arguments['name']) && empty($this->arguments['initials'])) {
+            throw new \InvalidArgumentException('Either name or initials must be provided', 1204028706);
+        }
+
+        $configuration = [
+            'name' => $this->arguments['name'] ?: '',
+            'initials' => $this->arguments['initials'] ?: '',
+            'mode' => $this->arguments['mode'] ? ColorMode::tryFrom($this->arguments['mode']) : ConfigurationUtility::get('mode', ColorMode::class),
+            'theme' => $this->arguments['theme'] ?: ConfigurationUtility::get('theme'),
+            'size' => $this->arguments['size'] ?: ConfigurationUtility::get('size'),
+            'fontSize' => $this->arguments['fontSize'] ?: ConfigurationUtility::get('fontSize'),
+            'fontPath' => $this->arguments['fontPath'] ?: ConfigurationUtility::get('fontPath'),
+            'imageFormat' => $this->arguments['imageFormat'] ? ImageFormat::tryFrom($this->arguments['imageFormat']) : ConfigurationUtility::get('imageFormat', ImageFormat::class),
+            'transform' => $this->arguments['transform'] ? Transform::tryFrom($this->arguments['transform']) : ConfigurationUtility::get('transform', Transform::class),
+        ];
+
+        $avatarService = Avatar::create(...$configuration);
+
+        $fileName = $avatarService->configToHash() . '.' . $configuration['imageFormat']->value;
+        $filePath = PathUtility::getImageFolder() . $fileName;
+
+        if (!file_exists($filePath)) {
+            $avatarService->saveAs($filePath);
+        }
+
+        return PathUtility::getWebPath($fileName);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This extension generates colorful backend user avatars using name initial letter
 
 * Generates out-of-the-box colorful avatars for backend users
 * Easily customizable and flexible configuration
-* Supports different predefined color modes and themes
+* Provides different predefined color modes and themes
+* Supports frontend user avatars with an additional viewhelper
 
 ## Requirements
 
@@ -115,7 +116,20 @@ If you want to use it for other use cases, you can use the following code snippe
 ```
 
 > [!NOTE]
-> See available parameters in the [AbstractImageProvider.php](Classes/Image/AbstractImageProvider.php#17)
+> See available parameters in the [AbstractImageProvider](Classes/Image/AbstractImageProvider.php#17)
+
+### ViewHelper
+
+You can use the `KonradMichalik\Typo3LetterAvatar\ViewHelpers\AvatarViewHelper` to generate an letter avatar image path in your Fluid templates, e.g. for frontend users:
+
+```html
+<html xmlns:letter="http://typo3.org/ns/KonradMichalik/Typo3LetterAvatar/ViewHelpers">
+
+<img src="{letter:avatar(name: 'John Doe')}" alt="Avatar of John Doe" />
+```
+
+> [!NOTE]
+> See available arguments in the [AvatarViewHelper](Classes/ViewHelpers/AvatarViewHelper.php).
 
 ### Console Command
 
@@ -177,5 +191,4 @@ This project is highly inspired by [avatar](https://github.com/laravolt/avatar) 
 
 ## License
 
-This project is licensed
-under [GNU General Public License 2.0 (or later)](LICENSE.md).
+This project is licensed under [GNU General Public License 2.0 (or later)](LICENSE.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new ViewHelper for Fluid templates, enabling generation of letter avatar images for frontend users with customizable options such as size, colors, and themes.
- **Documentation**
  - Updated README with detailed instructions and examples for using the new ViewHelper, including available arguments and template usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->