### PR TITLE
fix: exclude ext_emconf.php from PHP CS Fixer configuration

### DIFF
--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -36,6 +36,7 @@ $header = PhpCsFixerConfig\Rules\Header::create(
 $config = CodingStandards\CsFixerConfig::create();
 $finder = $config->getFinder()
     ->in(__DIR__)
+    ->notPath(['ext_emconf.php'])
     ->ignoreVCSIgnored(true)
     ->ignoreDotFiles(false)
 ;


### PR DESCRIPTION
Regarding the TYPO3 documentation and to prevent TER upload issues, the `ext_emconf.php` should not be fixed with a `declare(strict_types=1);` header.

See https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/FileStructure/ExtEmconf.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude specific configuration files from processing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->