### PR TITLE
refactor: streamline DDEV setup and consolidate Tests/.typo3-setup

### DIFF
--- a/Tests/.typo3-setup/composer.json
+++ b/Tests/.typo3-setup/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "test/typo3-letter-avatar-setup",
+    "description": "Local DDEV setup for typo3-letter-avatar",
+    "type": "project",
+    "require": {
+        "konradmichalik/typo3-letter-avatar": "@dev",
+        "test/sitepackage": "@dev",
+        "typo3/cms-base-distribution": "^11.5 || ^12.4 || ^13.4",
+        "typo3/cms-lowlevel": "^11.5 || ^12.4 || ^13.4",
+        "helhum/typo3-console": "^7.0 || ^8.1"
+    },
+    "repositories": [
+        { "type": "path", "url": "../../", "options": { "symlink": true } },
+        { "type": "path", "url": "./packages/sitepackage", "options": { "symlink": true } }
+    ],
+    "extra": {
+        "typo3/cms": {
+            "web-dir": ".Build/web",
+            "cms-package-dir": ".Build/vendor/typo3/cms"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true,
+            "helhum/dotenv-connector": true,
+            "php-http/discovery": true
+        }
+    }
+}

--- a/Tests/.typo3-setup/packages/sitepackage/composer.json
+++ b/Tests/.typo3-setup/packages/sitepackage/composer.json
@@ -1,26 +1,23 @@
 {
-"name": "test/sitepackage",
-"description": "typo3-natural-language-query testing",
-"license": "GPL-2.0-or-later",
-"type": "typo3-cms-extension",
-"authors": [
-	{
-	  "name": "#ddev-generated",
-	  "email": "x@y.com"
-	}
-],
-"require": {},
-"suggest": {},
-"conflict": {},
-"extra": {
-	"typo3/cms": {
-	  "extension-key": "sitepackage"
-	}
-},
-"version": "1.0.0",
-"autoload": {
-	"psr-4": {
-	  "Test\\Sitepackage\\": "Classes/"
-	}
-}
+    "name": "test/sitepackage",
+    "description": "typo3-letter-avatar testing site package",
+    "license": "GPL-2.0-or-later",
+    "type": "typo3-cms-extension",
+    "authors": [
+        {
+            "name": "#ddev-generated",
+            "email": "x@y.com"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "sitepackage"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Test\\Sitepackage\\": "Classes/"
+        }
+    }
 }


### PR DESCRIPTION
Adds standalone composer.json under `Tests/.typo3-setup/` so the local DDEV TYPO3 instance installs the extension via path-repository (mirrors xima-typo3-frontend-edit pattern). Fixes copy-paste leftover (description) and removes spurious `version` field in the sitepackage composer.json. Range still includes v11/v12 — narrowed in PR #4.