### PR TITLE
breaking: drop support for TYPO3 v11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,15 @@ name: Tests
 on:
   push:
     branches:
-      - '**'
+      - main
+      - 2.x-dev
+      - 1.x
+  pull_request: ~
 
 jobs:
   tests:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests.yml@main
+    with:
+      php-versions: '["8.1", "8.2", "8.3", "8.4"]'
+      typo3-versions: '["12.4", "13.4"]'
+      dependencies: '["highest", "lowest"]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,6 @@ jobs:
   tests:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests.yml@main
     with:
-      php-versions: '["8.1", "8.2", "8.3", "8.4"]'
+      php-versions: '["8.2", "8.3", "8.4"]'
       typo3-versions: '["12.4", "13.4"]'
       dependencies: '["highest", "lowest"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Removed
+- Support for TYPO3 v11.5
+- Support for Symfony Console v5

--- a/Tests/.typo3-setup/composer.json
+++ b/Tests/.typo3-setup/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "konradmichalik/typo3-letter-avatar": "@dev",
         "test/sitepackage": "@dev",
-        "typo3/cms-base-distribution": "^11.5 || ^12.4 || ^13.4",
-        "typo3/cms-lowlevel": "^11.5 || ^12.4 || ^13.4",
-        "helhum/typo3-console": "^7.0 || ^8.1"
+        "typo3/cms-base-distribution": "^12.4 || ^13.4",
+        "typo3/cms-lowlevel": "^12.4 || ^13.4",
+        "helhum/typo3-console": "^8.1"
     },
     "repositories": [
         { "type": "path", "url": "../../", "options": { "symlink": true } },

--- a/Tests/CGL/rector.php
+++ b/Tests/CGL/rector.php
@@ -47,7 +47,7 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
         ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '11.5.0-13.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.4.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     ->withSkip([

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
 	"require": {
 		"php": "^8.1",
 		"ext-mbstring": "*",
-		"symfony/console": "^5.4 || ^6.4 || ^7.0",
-		"typo3/cms-backend": "^11.0 || ^12.0 || ^13.0",
-		"typo3/cms-core": "^11.0 || ^12.0 || ^13.0",
-		"typo3fluid/fluid": "^2.7 || ^4.2"
+		"symfony/console": "^6.4 || ^7.0",
+		"typo3/cms-backend": "^12.0 || ^13.0",
+		"typo3/cms-core": "^12.0 || ^13.0",
+		"typo3fluid/fluid": "^4.2"
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^2.4 || ^3.0",
-		"helhum/typo3-console": "^7.0 || ^8.1",
+		"helhum/typo3-console": "^8.1",
 		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0",
-		"symfony/translation": "^5.0 || ^6.3 || ^7.0",
-		"typo3/cms-base-distribution": "^11.5 || ^12.4 || ^13.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4 || ^13.4"
+		"symfony/translation": "^6.3 || ^7.0",
+		"typo3/cms-base-distribution": "^12.4 || ^13.4",
+		"typo3/cms-lowlevel": "^12.4 || ^13.4"
 	},
 	"suggest": {
 		"ext-gd": "Image processing library for avatar generation",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"symfony/console": "^6.4 || ^7.0",
 		"typo3/cms-backend": "^12.0 || ^13.0",
 		"typo3/cms-core": "^12.0 || ^13.0",
-		"typo3fluid/fluid": "^4.2"
+		"typo3fluid/fluid": "^2.7 || ^4.2"
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^2.4 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50dff1b7262b1c2050722f16522fcdff",
+    "content-hash": "5c4b1dd52b41851aeeb87363af405bca",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "183c243ec2e68af69e371c4080bc93f5",
+    "content-hash": "50dff1b7262b1c2050722f16522fcdff",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '8.1.0-8.4.99',
-            'typo3' => '11.5.0-13.4.99',
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Removes TYPO3 v11.5 from supported range. Composer constraints, ext_emconf, Rector config, and local setup all updated. Symfony Console minimum bumped to v6.4, Fluid minimum to v4.2, helhum/typo3-console to ^8.1.

Part of v2.0.0 release. v12 drops in PR #4, PHP 8.1 in PR #5.