### PR TITLE
breaking: drop support for PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ All notable changes to this project will be documented in this file.
 - Support for Symfony Console v5
 - Support for Symfony Console v6
 - Support for Fluid v2
+- Support for PHP 8.1

--- a/Tests/CGL/rector.php
+++ b/Tests/CGL/rector.php
@@ -31,12 +31,12 @@ return RectorConfig::configure()
         $rootPath.'/ext_emconf.php',
         $rootPath.'/Tests/Unit',
     ])
-    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
         Typo3LevelSetList::UP_TO_TYPO3_13,
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
     ])
     ->withPHPStanConfigs([
         Typo3Option::PHPSTAN_FOR_RECTOR_PATH,
@@ -46,7 +46,7 @@ return RectorConfig::configure()
         ConvertImplicitVariablesToExplicitGlobalsRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.2.0-8.4.99',
         ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-13.4.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.1",
+		"php": "~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-mbstring": "*",
 		"symfony/console": "^7.0",
 		"typo3/cms-backend": "^13.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "504cda462b6bd7fe9eca7a433ead3dd8",
+    "content-hash": "2db9e19b5706fa0f18ddb9d67f103028",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -13062,7 +13062,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-mbstring": "*"
     },
     "platform-dev": {},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -29,7 +29,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.1',
     'constraints' => [
         'depends' => [
-            'php' => '8.1.0-8.4.99',
+            'php' => '8.2.0-8.4.99',
             'typo3' => '13.4.0-13.4.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
Sets minimum PHP to 8.2. Composer constraints: `~8.2.0 || ~8.3.0 || ~8.4.0`. ext_emconf: `8.2.0-8.4.99`. Rector configured for PHP 8.2 / TYPO3 13. Modernizes affected code paths via Rector PHP 8.2 set (readonly classes, new in initializers, etc.).

Part of v2.0.0 release. v14 + PHP 8.5 added in PRs #6 + #7.