### PR TITLE
feat: add support for TYPO3 v14

### DIFF
--- a/.ddev/commands/web/.install-14
+++ b/.ddev/commands/web/.install-14
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## #ddev-generated
+. .ddev/.typo3-setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 14.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 14
+
+# Install TYPO3 and related packages using Composer.
+# This command installs the TYPO3 base distribution, TYPO3 console, and additional packages.
+# Add any additional packages you want to install to the command below.
+composer req typo3/cms-base-distribution:'^14.0' \
+        helhum/typo3-console:'^8.3.1' \
+        $PACKAGE_NAME:'*@dev' \
+        test/sitepackage:'*@dev' \
+        --no-progress -n -d $BASE_PATH
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/14
+++ b/.ddev/commands/web/14
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for TYPO3 instance 14.
+## Usage: 14
+## Example: "ddev 14 composer du -o" or "ddev 14 typo3 cache:flush"
+
+. .ddev/.typo3-setup/scripts/utils.sh
+
+command=$@
+version=14
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/docker-compose.typo3-setup.yaml
+++ b/.ddev/docker-compose.typo3-setup.yaml
@@ -5,7 +5,7 @@ services:
             - EXTENSION_KEY=typo3_letter_avatar
             - EXTENSION_NAME=typo3-letter-avatar
             - PACKAGE_NAME=konradmichalik/typo3-letter-avatar
-            - TYPO3_VERSIONS=11 12 13
+            - TYPO3_VERSIONS=13 14
 
             # TYPO3 v11 and v12 config
             - TYPO3_INSTALL_DB_DRIVER=mysqli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,5 +12,5 @@ jobs:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests.yml@main
     with:
       php-versions: '["8.2", "8.3", "8.4"]'
-      typo3-versions: '["13.4"]'
+      typo3-versions: '["13.4", "14.3"]'
       dependencies: '["highest", "lowest"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Support for TYPO3 v14
+- Support for Symfony 8
+- Support for Fluid v5
+
 ### Removed
 - Support for TYPO3 v11.5
 - Support for TYPO3 v12.4

--- a/Tests/.typo3-setup/composer.json
+++ b/Tests/.typo3-setup/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "konradmichalik/typo3-letter-avatar": "@dev",
         "test/sitepackage": "@dev",
-        "typo3/cms-base-distribution": "^13.4",
-        "typo3/cms-lowlevel": "^13.4",
-        "helhum/typo3-console": "^8.1"
+        "typo3/cms-base-distribution": "^13.4 || ^14.0",
+        "typo3/cms-lowlevel": "^13.4 || ^14.0",
+        "helhum/typo3-console": "^8.3.1"
     },
     "repositories": [
         { "type": "path", "url": "../../", "options": { "symlink": true } },

--- a/Tests/CGL/rector.php
+++ b/Tests/CGL/rector.php
@@ -35,7 +35,7 @@ return RectorConfig::configure()
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_13,
+        Typo3LevelSetList::UP_TO_TYPO3_14,
         LevelSetList::UP_TO_PHP_82,
     ])
     ->withPHPStanConfigs([
@@ -47,7 +47,7 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
         ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.2.0-8.4.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-13.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     ->withSkip([

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
 	"require": {
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-mbstring": "*",
-		"symfony/console": "^7.0",
-		"typo3/cms-backend": "^13.4",
-		"typo3/cms-core": "^13.4",
-		"typo3fluid/fluid": "^4.2"
+		"symfony/console": "^7.0 || ^8.0",
+		"typo3/cms-backend": "^13.4 || ^14.0",
+		"typo3/cms-core": "^13.4 || ^14.0",
+		"typo3fluid/fluid": "^4.2 || ^5.0"
 	},
 	"require-dev": {
-		"eliashaeussler/version-bumper": "^2.4 || ^3.0",
-		"helhum/typo3-console": "^8.1",
-		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0",
-		"symfony/translation": "^7.0",
-		"typo3/cms-base-distribution": "^13.4",
-		"typo3/cms-lowlevel": "^13.4"
+		"eliashaeussler/version-bumper": "^3.1.1",
+		"helhum/typo3-console": "^8.3.1",
+		"phpunit/phpunit": "^11.0 || ^12.0",
+		"symfony/translation": "^7.0 || ^8.0",
+		"typo3/cms-base-distribution": "^13.4 || ^14.0",
+		"typo3/cms-lowlevel": "^13.4 || ^14.0"
 	},
 	"suggest": {
 		"ext-gd": "Image processing library for avatar generation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2db9e19b5706fa0f18ddb9d67f103028",
+    "content-hash": "daeff9e865af4592fd045a9ee2120ea6",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '8.2.0-8.4.99',
-            'typo3' => '13.4.0-13.4.99',
+            'typo3' => '13.4.0-14.3.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Adds TYPO3 v14 support. Range now `^13.4 || ^14.0`. Symfony 8 + Fluid 5 added to supported set. Rector configured for Typo3LevelSetList::UP_TO_TYPO3_14. CI matrix expanded to PHP 8.2-8.4 × TYPO3 13.4/14.3. PHPUnit minimum bumped to ^11.0. DDEV v14 commands added.

Closes superseded Renovate PRs: #26, #28, #29.

Part of v2.0.0 release. PHP 8.5 added in PR #7.