### PR TITLE
chore: pin PHP versions in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,11 @@
 	"ignorePaths": [
 		"package-lock.json"
 	],
-	"enabled": false
+	"enabled": false,
+	"packageRules": [
+		{
+			"matchPackageNames": ["php"],
+			"enabled": false
+		}
+	]
 }


### PR DESCRIPTION
Prevents Renovate from auto-bumping the PHP constraint in composer.json. PHP support is a deliberate decision, not an automated one.