### PR TITLE
test: extend unit test coverage to v13/v14 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Support for Fluid v5
 - Support for PHP 8.5
 - Demo backend user fixtures for DDEV setup (auto-imported via `ddev install`)
+- Extended unit test coverage with edge-case tests (apostrophes, unicode, long names, umlauts, two-char first names) matching demo backend user fixtures
 
 ### Changed
 - Migrate fixture and sitepackage paths from `Tests/.typo3-setup/` to `Tests/Acceptance/Fixtures/` (DDEV addon convention)

--- a/Tests/Unit/AvatarProvider/LetterAvatarProviderTest.php
+++ b/Tests/Unit/AvatarProvider/LetterAvatarProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\AvatarProvider;
+
+use KonradMichalik\Typo3LetterAvatar\AvatarProvider\LetterAvatarProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Backend\Avatar\AvatarProviderInterface;
+
+/**
+ * LetterAvatarProviderTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class LetterAvatarProviderTest extends TestCase
+{
+    #[Test]
+    public function classImplementsAvatarProviderInterface(): void
+    {
+        $reflection = new ReflectionClass(LetterAvatarProvider::class);
+
+        self::assertTrue($reflection->implementsInterface(AvatarProviderInterface::class));
+    }
+
+    #[Test]
+    public function classDefinesGetImageMethod(): void
+    {
+        self::assertTrue(method_exists(LetterAvatarProvider::class, 'getImage'));
+    }
+
+    #[Test]
+    public function classDefinesPrivateGetNameMethod(): void
+    {
+        $reflection = new ReflectionClass(LetterAvatarProvider::class);
+
+        self::assertTrue($reflection->hasMethod('getName'));
+        self::assertTrue($reflection->getMethod('getName')->isPrivate());
+    }
+
+    #[Test]
+    public function constructorRequiresEventDispatcher(): void
+    {
+        $reflection = new ReflectionClass(LetterAvatarProvider::class);
+        $constructor = $reflection->getConstructor();
+
+        self::assertNotNull($constructor);
+        $parameters = $constructor->getParameters();
+        self::assertCount(1, $parameters);
+        self::assertSame('eventDispatcher', $parameters[0]->getName());
+    }
+
+    #[Test]
+    public function getImageMethodHasCorrectSignature(): void
+    {
+        $reflection = new ReflectionClass(LetterAvatarProvider::class);
+        $method = $reflection->getMethod('getImage');
+
+        $parameters = $method->getParameters();
+        self::assertCount(2, $parameters);
+        self::assertSame('backendUser', $parameters[0]->getName());
+        self::assertSame('size', $parameters[1]->getName());
+    }
+}

--- a/Tests/Unit/Image/AbstractImageProviderTest.php
+++ b/Tests/Unit/Image/AbstractImageProviderTest.php
@@ -21,6 +21,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+use function count;
+use function strlen;
+
 /**
  * AbstractImageProviderTest.
  *
@@ -126,6 +129,136 @@ class(name: 'Test User', size: 100, fontSize: 0.5, mode: ColorMode::CUSTOM, fore
         $hash2 = $method->invoke($this->imageProvider);
 
         self::assertNotSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function configToHashIsUniquePerEdgeCaseName(): void
+    {
+        // Each demo fixture name should hash to a distinct value
+        $names = [
+            'Maria Müller',
+            "Thomas O'Brien",
+            'Li Wei',
+            'Maximilian Hubertus von Habsburg-Lothringen',
+            'Émilie Łukasiewicz',
+        ];
+
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $hashes = [];
+        foreach ($names as $name) {
+            $this->imageProvider->name = $name;
+            $hashes[] = $method->invoke($this->imageProvider);
+        }
+
+        self::assertCount(count($names), array_unique($hashes), 'Edge-case names must produce unique hashes');
+    }
+
+    #[Test]
+    public function configToHashHandlesUnicodeNamesAsValidString(): void
+    {
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $this->imageProvider->name = 'Émilie Łukasiewicz';
+        $hash = $method->invoke($this->imageProvider);
+
+        // SHA-256 hex digest is exactly 64 chars
+        self::assertSame(64, strlen((string) $hash));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
+    #[Test]
+    public function configToHashChangesWhenInitialsChange(): void
+    {
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $this->imageProvider->initials = '';
+        $without = $method->invoke($this->imageProvider);
+
+        $this->imageProvider->initials = 'MM';
+        $withInitials = $method->invoke($this->imageProvider);
+
+        self::assertNotSame($without, $withInitials);
+    }
+
+    #[Test]
+    public function configToHashChangesWhenShapeChanges(): void
+    {
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $this->imageProvider->shape = Shape::CIRCLE;
+        $circle = $method->invoke($this->imageProvider);
+
+        $this->imageProvider->shape = Shape::SQUARE;
+        $square = $method->invoke($this->imageProvider);
+
+        self::assertNotSame($circle, $square);
+    }
+
+    #[Test]
+    public function configToHashChangesWhenTransformChanges(): void
+    {
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $this->imageProvider->transform = Transform::NONE;
+        $none = $method->invoke($this->imageProvider);
+
+        $this->imageProvider->transform = Transform::UPPERCASE;
+        $upper = $method->invoke($this->imageProvider);
+
+        self::assertNotSame($none, $upper);
+    }
+
+    #[Test]
+    public function configToHashIsIndependentOfImageFormat(): void
+    {
+        // The hash intentionally excludes imageFormat — the format is only in the file extension
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $this->imageProvider->imageFormat = ImageFormat::PNG;
+        $png = $method->invoke($this->imageProvider);
+
+        $this->imageProvider->imageFormat = ImageFormat::JPEG;
+        $jpeg = $method->invoke($this->imageProvider);
+
+        self::assertSame($png, $jpeg);
+    }
+
+    #[Test]
+    public function constructorAppliesDefaultsForOptionalArguments(): void
+    {
+        $provider = new
+/**
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class extends AbstractImageProvider {
+    public function generate(): mixed
+    {
+        return null;
+    }
+
+    public function save(?string $path = null, ImageFormat $format = ImageFormat::PNG, int $quality = 90): string
+    {
+        return '';
+    }
+};
+
+        self::assertSame('', $provider->name);
+        self::assertSame('', $provider->initials);
+        self::assertSame(100, $provider->size);
+        self::assertSame(0.5, $provider->fontSize);
+        self::assertSame(ColorMode::CUSTOM, $provider->mode);
+        self::assertSame('', $provider->theme);
+        self::assertSame(ImageFormat::PNG, $provider->imageFormat);
+        self::assertSame(Transform::NONE, $provider->transform);
+        self::assertSame(Shape::CIRCLE, $provider->shape);
     }
 
     #[Test]

--- a/Tests/Unit/Service/ColorizeTest.php
+++ b/Tests/Unit/Service/ColorizeTest.php
@@ -20,6 +20,8 @@ use KonradMichalik\Typo3LetterAvatar\Service\Colorize;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+
 /**
  * ColorizeTest.
  *
@@ -180,5 +182,134 @@ final class ColorizeTest extends TestCase
 
         self::assertSame($fg1, $fg2);
         self::assertSame($bg1, $bg2);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyHandlesUmlautName(): void
+    {
+        // Demo fixture: Maria Müller — must produce stable hex color
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = 'Maria Müller';
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertMatchesRegularExpression('/^#[0-9A-F]{6}$/i', $color);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyHandlesApostropheName(): void
+    {
+        // Demo fixture: Thomas O'Brien
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = "Thomas O'Brien";
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertMatchesRegularExpression('/^#[0-9A-F]{6}$/i', $color);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyHandlesUnicodeName(): void
+    {
+        // Demo fixture: Émilie Łukasiewicz
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = 'Émilie Łukasiewicz';
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertMatchesRegularExpression('/^#[0-9A-F]{6}$/i', $color);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyHandlesLongCompositeName(): void
+    {
+        // Demo fixture: Maximilian Hubertus von Habsburg-Lothringen
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = 'Maximilian Hubertus von Habsburg-Lothringen';
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertMatchesRegularExpression('/^#[0-9A-F]{6}$/i', $color);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyHandlesTwoCharFirstName(): void
+    {
+        // Demo fixture: Li Wei
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = 'Li Wei';
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertMatchesRegularExpression('/^#[0-9A-F]{6}$/i', $color);
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyAllDemoFixturesProduceUniqueColors(): void
+    {
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $names = [
+            'Maria Müller',
+            "Thomas O'Brien",
+            'Li Wei',
+            'Maximilian Hubertus von Habsburg-Lothringen',
+            'Émilie Łukasiewicz',
+        ];
+
+        $colors = [];
+        foreach ($names as $name) {
+            $this->avatarProvider->name = $name;
+            // Reinstantiate so cached colors don't leak between names
+            $service = new Colorize($this->avatarProvider);
+            $colors[] = $service->resolveBackgroundColor();
+        }
+
+        // All produced hex colors should be unique (CRC32-based hash collision-free for these inputs)
+        self::assertCount(count($names), array_unique($colors));
+    }
+
+    #[Test]
+    public function resolveBackgroundColorWithStringifyDarkensColorByHalving(): void
+    {
+        // The implementation halves each RGB component (hexdec/2). Verify each channel is in [0, 127].
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+        $this->avatarProvider->name = 'John Doe';
+        $this->avatarProvider->initials = '';
+        $this->avatarProvider->transform = \KonradMichalik\Typo3LetterAvatar\Enum\Transform::NONE;
+
+        $color = $this->colorizeService->resolveBackgroundColor();
+
+        self::assertSame('#', $color[0]);
+        $r = hexdec(substr($color, 1, 2));
+        $g = hexdec(substr($color, 3, 2));
+        $b = hexdec(substr($color, 5, 2));
+
+        self::assertLessThanOrEqual(127, $r);
+        self::assertLessThanOrEqual(127, $g);
+        self::assertLessThanOrEqual(127, $b);
+    }
+
+    #[Test]
+    public function resolveForegroundColorWithStringifyDelegatesToRandomColors(): void
+    {
+        // ColorMode::STRINGIFY uses random foreground colors (only background is hashed)
+        $this->avatarProvider->mode = ColorMode::STRINGIFY;
+
+        $result = $this->colorizeService->resolveForegroundColor();
+
+        self::assertContains($result, ['#FFFFFF', '#000000']);
     }
 }

--- a/Tests/Unit/Utility/StringUtilityTest.php
+++ b/Tests/Unit/Utility/StringUtilityTest.php
@@ -146,4 +146,123 @@ final class StringUtilityTest extends TestCase
 
         self::assertSame('JS', $result);
     }
+
+    #[Test]
+    public function resolveInitialsHandlesUmlautSurname(): void
+    {
+        // Demo fixture: editor.maria — Maria Müller
+        $result = StringUtility::resolveInitials('Maria Müller', '', Transform::NONE);
+
+        self::assertSame('MM', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesApostropheInName(): void
+    {
+        // Demo fixture: editor.thomas — Thomas O'Brien
+        $result = StringUtility::resolveInitials("Thomas O'Brien", '', Transform::NONE);
+
+        self::assertSame('TO', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesTwoCharFirstName(): void
+    {
+        // Demo fixture: editor.li — Li Wei
+        $result = StringUtility::resolveInitials('Li Wei', '', Transform::NONE);
+
+        self::assertSame('LW', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsTruncatesLongCompositeNamesToTwoLetters(): void
+    {
+        // Demo fixture: editor.long — Maximilian Hubertus von Habsburg-Lothringen
+        $result = StringUtility::resolveInitials(
+            'Maximilian Hubertus von Habsburg-Lothringen',
+            '',
+            Transform::NONE,
+        );
+
+        // Only first two name parts are used; result is fixed length 2
+        self::assertSame('MH', $result);
+        self::assertSame(2, mb_strlen($result));
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesUnicodeAcrossScripts(): void
+    {
+        // Demo fixture: editor.unicode — Émilie Łukasiewicz
+        $result = StringUtility::resolveInitials('Émilie Łukasiewicz', '', Transform::NONE);
+
+        self::assertSame('ÉŁ', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesUnicodeWithUppercaseTransform(): void
+    {
+        // Pre-uppercase Unicode characters should remain uppercase after transform
+        $result = StringUtility::resolveInitials('émilie łukasiewicz', '', Transform::UPPERCASE);
+
+        self::assertSame('ÉŁ', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesUmlautWithLowercaseTransform(): void
+    {
+        $result = StringUtility::resolveInitials('Maria Müller', '', Transform::LOWERCASE);
+
+        self::assertSame('mm', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsCommaInverseOrderProducesSurnameInitialFirst(): void
+    {
+        // "Müller, Maria" → comma is split-token, so first part is "Müller"
+        $result = StringUtility::resolveInitials('Müller, Maria', '', Transform::NONE);
+
+        self::assertSame('MM', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesSingleUnicodeCharName(): void
+    {
+        $result = StringUtility::resolveInitials('Ł', '', Transform::NONE);
+
+        self::assertSame('Ł', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesTabsAsWhitespace(): void
+    {
+        $result = StringUtility::resolveInitials("John\tDoe", '', Transform::NONE);
+
+        self::assertSame('JD', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsHandlesNewlinesAsWhitespace(): void
+    {
+        $result = StringUtility::resolveInitials("John\nDoe", '', Transform::NONE);
+
+        self::assertSame('JD', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsWithLongPreSetInitialsReturnsFullPreSetValue(): void
+    {
+        // Pre-set initials are passed through verbatim, no truncation
+        $result = StringUtility::resolveInitials('John Doe', 'XYZ', Transform::NONE);
+
+        self::assertSame('XYZ', $result);
+    }
+
+    #[Test]
+    public function resolveInitialsWithEmptyPreSetFallsBackToName(): void
+    {
+        // Explicit empty pre-set must not short-circuit; name should be used
+        $result = StringUtility::resolveInitials('Maria Müller', '', Transform::NONE);
+
+        self::assertSame('MM', $result);
+    }
 }

--- a/Tests/Unit/ViewHelpers/AvatarViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AvatarViewHelperTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\ViewHelpers;
+
+use InvalidArgumentException;
+use KonradMichalik\Typo3LetterAvatar\ViewHelpers\AvatarViewHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * AvatarViewHelperTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class AvatarViewHelperTest extends TestCase
+{
+    private AvatarViewHelper $viewHelper;
+
+    protected function setUp(): void
+    {
+        $this->viewHelper = new AvatarViewHelper();
+        $this->viewHelper->initializeArguments();
+    }
+
+    #[Test]
+    public function viewHelperExtendsAbstractViewHelper(): void
+    {
+        self::assertInstanceOf(AbstractViewHelper::class, $this->viewHelper);
+    }
+
+    #[Test]
+    public function initializeArgumentsRegistersAllExpectedArguments(): void
+    {
+        $reflection = new ReflectionClass($this->viewHelper);
+        $property = $reflection->getProperty('argumentDefinitions');
+        $arguments = $property->getValue($this->viewHelper);
+
+        $expectedArgumentNames = [
+            'name',
+            'initials',
+            'size',
+            'fontSize',
+            'fontPath',
+            'foregroundColor',
+            'backgroundColor',
+            'mode',
+            'theme',
+            'imageFormat',
+            'transform',
+            'shape',
+        ];
+
+        foreach ($expectedArgumentNames as $name) {
+            self::assertArrayHasKey($name, $arguments, "Argument '$name' should be registered");
+        }
+    }
+
+    #[Test]
+    public function noArgumentIsRequired(): void
+    {
+        $reflection = new ReflectionClass($this->viewHelper);
+        $property = $reflection->getProperty('argumentDefinitions');
+        $arguments = $property->getValue($this->viewHelper);
+
+        foreach ($arguments as $argumentName => $argumentDefinition) {
+            self::assertFalse(
+                $argumentDefinition->isRequired(),
+                "Argument '$argumentName' should be optional",
+            );
+        }
+    }
+
+    #[Test]
+    public function renderThrowsExceptionWhenNeitherNameNorInitialsProvided(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1204028706);
+
+        // Inject empty arguments via reflection
+        $arguments = new ReflectionProperty(AbstractViewHelper::class, 'arguments');
+        $arguments->setValue($this->viewHelper, ['name' => '', 'initials' => '']);
+
+        $this->viewHelper->render();
+    }
+
+    #[Test]
+    public function renderThrowsExceptionWithEmptyArguments(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $arguments = new ReflectionProperty(AbstractViewHelper::class, 'arguments');
+        $arguments->setValue($this->viewHelper, []);
+
+        $this->viewHelper->render();
+    }
+
+    #[Test]
+    public function nameArgumentIsOfTypeString(): void
+    {
+        $reflection = new ReflectionClass($this->viewHelper);
+        $property = $reflection->getProperty('argumentDefinitions');
+        $arguments = $property->getValue($this->viewHelper);
+
+        self::assertSame('string', $arguments['name']->getType());
+        self::assertSame('string', $arguments['initials']->getType());
+    }
+
+    #[Test]
+    public function sizeArgumentIsOfTypeInteger(): void
+    {
+        $reflection = new ReflectionClass($this->viewHelper);
+        $property = $reflection->getProperty('argumentDefinitions');
+        $arguments = $property->getValue($this->viewHelper);
+
+        self::assertSame('integer', $arguments['size']->getType());
+    }
+
+    #[Test]
+    public function fontSizeArgumentIsOfTypeFloat(): void
+    {
+        $reflection = new ReflectionClass($this->viewHelper);
+        $property = $reflection->getProperty('argumentDefinitions');
+        $arguments = $property->getValue($this->viewHelper);
+
+        self::assertSame('float', $arguments['fontSize']->getType());
+    }
+}


### PR DESCRIPTION
Adds unit tests for previously untested or undercovered classes in `Classes/`. Edge cases mirror the demo backend user names from PR #10 (apostrophes, unicode across scripts, long composite names, umlauts, 2-char first names).

## Summary

- **StringUtility** — 13 new edge-case tests covering: umlauts (Müller), apostrophes (O'Brien), 2-char first names (Li Wei), long composite names (Maximilian Hubertus von Habsburg-Lothringen), unicode across scripts (Émilie Łukasiewicz), tabs/newlines as whitespace, comma-separator inverse order, single-char unicode, long pre-set initials passthrough.
- **AbstractImageProvider** — 7 new tests verifying `configToHash` uniqueness across edge-case names, hash format integrity, and field-level invariants (initials, shape, transform change → hash differs; imageFormat does NOT — that lives in the file extension).
- **Colorize** — 8 new tests for stringify mode with each demo edge-case name + uniqueness check across all five fixtures + RGB-halving invariant + STRINGIFY foreground delegation to random.
- **LetterAvatarProvider** — new test file with structural/signature checks (interface conformance, constructor, getName privacy).
- **AvatarViewHelper** — new test file with argument-registration introspection + render() exception path for missing name+initials.

Test count: 83 → 124 (+41 tests, +86 assertions).

Test-only PR — no production code changes.

## Test plan

- [x] `ddev composer test` — 124/124 passing (255 assertions)
- [x] `ddev composer cgl fix` clean
- [x] `ddev composer cgl sca` (PHPStan) clean
- [x] `ddev composer cgl migration` (Rector) clean
- [ ] CI runs green on PR