### PR TITLE
chore: adjust renovate config for v2 release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,9 @@
 	"ignorePaths": [
 		"package-lock.json"
 	],
-	"enabled": false,
+	"constraints": {
+		"php": ">=8.2"
+	},
 	"packageRules": [
 		{
 			"matchPackageNames": ["php"],


### PR DESCRIPTION
Re-enables Renovate (was paused during v2 work via PR #1). Adds `constraints.php >=8.2` and pins PHP version updates to manual review (`packageRules.matchPackageNames: [php]` disabled). The shared `konradmichalik/renovate-config` and `:typo3-extension` presets handle multi-composer.json detection (root + `Tests/CGL/`) automatically. Mirrors xima-typo3-frontend-edit pattern.