### PR TITLE
fix(ddev): drop v11/v12 from additional_hostnames

### DIFF
--- a/.ddev/commands/web/cgl
+++ b/.ddev/commands/web/cgl
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+## Description: Run CGL script for the package files
+## Usage: cgl [command] [options]
+## Example: ddev cgl lint\nddev cgl fix\nddev cgl migration\nddev cgl sca\nddev cgl lint:composer\nddev cgl fix:composer
+
+composer -d /var/www/html/Tests/CGL "$@"

--- a/.ddev/config.typo3-setup.yaml
+++ b/.ddev/config.typo3-setup.yaml
@@ -2,8 +2,6 @@ type: php
 docroot: .Build
 webserver_type: apache-fpm
 additional_hostnames:
-  - 11.typo3-letter-avatar
-  - 12.typo3-letter-avatar
   - 13.typo3-letter-avatar
   - 14.typo3-letter-avatar
 hooks:


### PR DESCRIPTION
PR #48 cleanup forgot the addon's `additional_hostnames` block. With 4 hostnames (11/12/13/14), DDEV/traefik silently dropped `14` from the merged HostRegexp rule, breaking the v14 frontend URL. Narrowed to v13/v14 (matches xima-typo3-frontend-edit pattern). After `ddev restart`, https://14.typo3-letter-avatar.ddev.site/ routes correctly to apache → TYPO3 v14.