### PR TITLE
fix: register letter avatar provider via DI tag for TYPO3 v14

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,7 +13,7 @@ services:
       tags:
         - name: backend.avatar_provider
           identifier: letterAvatar
-          after: [defaultAvatarProvider]
+          after: defaultAvatarProvider
 
     KonradMichalik\Typo3LetterAvatar\Command\ClearAvatarsCommand:
         tags:

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,6 +10,10 @@ services:
 
     KonradMichalik\Typo3LetterAvatar\AvatarProvider\LetterAvatarProvider:
       public: true
+      tags:
+        - name: backend.avatar_provider
+          identifier: letterAvatar
+          after: [defaultAvatarProvider]
 
     KonradMichalik\Typo3LetterAvatar\Command\ClearAvatarsCommand:
         tags:


### PR DESCRIPTION
**Bug:** Letter avatars don't appear on TYPO3 v14 backends. They work fine on v13.

**Root cause:** TYPO3 v14 changed the avatar-provider discovery mechanism:

| | v13 | v14 |
|---|---|---|
| `AvatarProviderInterface` | unchanged | unchanged ✓ |
| Registration source | `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['backend']['avatarProviders']` | DI services tagged `backend.avatar_provider`, collected by `AvatarProviderPass` |
| Sorting | `DependencyOrderingService` over the globals array | `AvatarProviderPass` + tag attributes |

The legacy globals registration in `ext_localconf.php` is **ignored** by v14 — providers must be DI-tagged.

**Fix:** Add the `backend.avatar_provider` tag (with `identifier` + `after`) in `Configuration/Services.yaml`. v13 ignores unknown tags and continues to use the globals registration; v14 picks up the tag via the compiler pass and instantiates the provider through DI.

**Verified locally** in DDEV with both v13 and v14: avatars render for the demo backend users on both versions.