### PR TITLE
docs: add Why section and font character coverage note

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -19,6 +19,8 @@ Select color theme when using "Theme" mode. Available themes defined in `ext_loc
 ### Font
 Choose from various included font types for avatar generation.
 
+> **Character coverage:** Not every bundled font supports the full set of Latin diacritics. Display fonts (`Norwester`, `Chewy`) ship with a Basic Latin glyph set only — names containing characters such as `É`, `Ł`, `Ä`, `Ø`, `Č`, etc. will render with empty letters. For backends with international users, prefer `OpenSans-Bold.ttf` or `NotoSans-Bold.ttf`, which cover most European Latin diacritics.
+
 ## Custom Configuration
 
 Override default configuration in your extension:

--- a/README.md
+++ b/README.md
@@ -18,17 +18,8 @@ This TYPO3 extension generates colorful backend user avatars using name initials
 
 ![user-list.jpg](Documentation/Images/user-list.jpg)
 
-## 🤔 Why
-
-TYPO3's default backend shows a generic silhouette icon for every user without a manually uploaded avatar. In teams of more than a handful of editors, the user list, log entries, and edit history quickly turn into a wall of identical icons — making it harder to scan and recognize who did what.
-
-This extension fills that gap by generating recognizable letter avatars from each user's real name (or username) on the fly:
-
-* **Visual scannability** — distinct color + initials per user makes lists, history entries, and review screens easier to read at a glance.
-* **No uploads required** — works automatically for every backend user, no editor onboarding step needed.
-* **Privacy-friendly** — no profile pictures, no external avatar services (Gravatar, etc.), no third-party data transfer. Everything is generated locally.
-* **Deterministic colors** — the same name always produces the same color (in `stringify` and `pairs` modes), so users keep their identity across sessions.
-* **Configurable** — pick from multiple color modes, themes, fonts, and shapes; or extend with custom themes via `ext_localconf.php`.
+> [!NOTE]
+> TYPO3's default backend shows the same silhouette for every user without an uploaded avatar — making large user lists hard to scan. This extension generates a colored letter avatar per user automatically: no uploads, no external services, deterministic colors per name.
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ This TYPO3 extension generates colorful backend user avatars using name initials
 
 ![user-list.jpg](Documentation/Images/user-list.jpg)
 
+## 🤔 Why
+
+TYPO3's default backend shows a generic silhouette icon for every user without a manually uploaded avatar. In teams of more than a handful of editors, the user list, log entries, and edit history quickly turn into a wall of identical icons — making it harder to scan and recognize who did what.
+
+This extension fills that gap by generating recognizable letter avatars from each user's real name (or username) on the fly:
+
+* **Visual scannability** — distinct color + initials per user makes lists, history entries, and review screens easier to read at a glance.
+* **No uploads required** — works automatically for every backend user, no editor onboarding step needed.
+* **Privacy-friendly** — no profile pictures, no external avatar services (Gravatar, etc.), no third-party data transfer. Everything is generated locally.
+* **Deterministic colors** — the same name always produces the same color (in `stringify` and `pairs` modes), so users keep their identity across sessions.
+* **Configurable** — pick from multiple color modes, themes, fonts, and shapes; or extend with custom themes via `ext_localconf.php`.
+
 ## ✨ Features
 
 * Generates out-of-the-box colorful avatars for backend users


### PR DESCRIPTION
Two related doc additions surfaced while testing the v2 demo fixtures:

**README — new `## Why` section** between the intro and Features. Explains motivation: visual scannability of user lists/history, no upload onboarding, privacy-friendly (no Gravatar/external services), deterministic colors, configurability.

**Documentation/Configuration.md — `Font` section** now warns that display fonts shipped with the extension (Norwester, Chewy) only cover Basic Latin. Names with diacritics (`É`, `Ł`, `Ä`, `Ø`, `Č`, …) render as empty letters. Recommends `OpenSans-Bold.ttf` / `NotoSans-Bold.ttf` for backends with international users — both ship with the extension and support broad Latin diacritics.