### PR TITLE
fix: fall back to username when realName is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 - Migrated fixture and sitepackage paths from `Tests/.typo3-setup/` to `Tests/Acceptance/Fixtures/` (DDEV addon convention)
 - Update `konradmichalik/ddev-typo3-multi-version-extension` addon for fixture auto-discovery
 
+### Fixed
+- Register avatar provider via DI tag `backend.avatar_provider` (TYPO3 v14 ignores the legacy globals registration)
+- Fall back to `username` when `realName` is empty (not only when missing) — backend users without a real name (e.g. `admin`) now get an avatar based on their username
+
 ### Removed
 - Support for TYPO3 v11.5
 - Support for TYPO3 v12.4

--- a/Classes/AvatarProvider/LetterAvatarProvider.php
+++ b/Classes/AvatarProvider/LetterAvatarProvider.php
@@ -68,10 +68,14 @@ class LetterAvatarProvider implements AvatarProviderInterface
 
     private function getName(array $backendUser): string
     {
+        $username = $backendUser['username'] ?? '';
+
         if (ConfigurationUtility::get('prioritizeRealName')) {
-            return $backendUser['realName'] ?? $backendUser['username'];
+            $realName = trim($backendUser['realName'] ?? '');
+
+            return '' !== $realName ? $realName : $username;
         }
 
-        return $backendUser['username'];
+        return $username;
     }
 }


### PR DESCRIPTION
Backend users without a configured `realName` (the default `admin` being the obvious one) had `realName=''` in the user array. The old `$backendUser['realName'] ?? $backendUser['username']` null-coalesce only fires when the key is missing or null — empty string passed through, `StringUtility::resolveInitials('')` returned `''`, and the avatar rendered without letters.

Now `getName` trims and tests the realName for non-empty before returning, falling back to username otherwise. Also defensively defaults `username` to `''` if the key is somehow missing.