### PR TITLE
fix: resolve image driver string from TYPO3 GFX processor config

### DIFF
--- a/Classes/Image/Avatar.php
+++ b/Classes/Image/Avatar.php
@@ -16,6 +16,8 @@ namespace KonradMichalik\Typo3LetterAvatar\Image;
 use KonradMichalik\Typo3LetterAvatar\Enum\ImageDriver;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\{Gd, Gmagick, Imagick};
 
+use function is_string;
+
 /**
  * Avatar.
  *
@@ -26,13 +28,17 @@ class Avatar
 {
     public static function create(...$args): LetterAvatarInterface
     {
-        $imageDriver = $args['imageDriver'] ?? $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'];
+        $imageDriver = $args['imageDriver'] ?? $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] ?? null;
         unset($args['imageDriver']);
 
-        return match ($imageDriver) {
-            ImageDriver::GD => new Gd(...$args),
-            ImageDriver::GMAGICK => new Gmagick(...$args),
-            default => new Imagick(...$args),
+        $driver = $imageDriver instanceof ImageDriver
+            ? $imageDriver
+            : (is_string($imageDriver) ? ImageDriver::tryFrom($imageDriver) : null);
+
+        return match ($driver) {
+            ImageDriver::GMAGICK => class_exists(\Gmagick::class) ? new Gmagick(...$args) : new Gd(...$args),
+            ImageDriver::IMAGICK => class_exists(\Imagick::class) ? new Imagick(...$args) : new Gd(...$args),
+            default => new Gd(...$args),
         };
     }
 }

--- a/Tests/Unit/Image/AvatarTest.php
+++ b/Tests/Unit/Image/AvatarTest.php
@@ -36,6 +36,10 @@ final class AvatarTest extends TestCase
     #[Test]
     public function createReturnsImagickDriverByDefault(): void
     {
+        if (!class_exists(\Imagick::class)) {
+            self::markTestSkipped('ext-imagick is not available.');
+        }
+
         $avatar = Avatar::create(name: 'John Doe');
 
         self::assertInstanceOf(Imagick::class, $avatar);
@@ -52,6 +56,10 @@ final class AvatarTest extends TestCase
     #[Test]
     public function createReturnsGmagickDriverWhenSpecified(): void
     {
+        if (!class_exists(\Gmagick::class)) {
+            self::markTestSkipped('ext-gmagick is not available.');
+        }
+
         $avatar = Avatar::create(name: 'John Doe', imageDriver: ImageDriver::GMAGICK);
 
         self::assertInstanceOf(Gmagick::class, $avatar);
@@ -60,6 +68,10 @@ final class AvatarTest extends TestCase
     #[Test]
     public function createReturnsImagickDriverWhenSpecified(): void
     {
+        if (!class_exists(\Imagick::class)) {
+            self::markTestSkipped('ext-imagick is not available.');
+        }
+
         $avatar = Avatar::create(name: 'John Doe', imageDriver: ImageDriver::IMAGICK);
 
         self::assertInstanceOf(Imagick::class, $avatar);
@@ -68,7 +80,11 @@ final class AvatarTest extends TestCase
     #[Test]
     public function createUsesGlobalProcessorConfiguration(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = ImageDriver::GMAGICK;
+        if (!class_exists(\Gmagick::class)) {
+            self::markTestSkipped('ext-gmagick is not available.');
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = ImageDriver::GMAGICK->value;
 
         $avatar = Avatar::create(name: 'John Doe');
 
@@ -78,7 +94,49 @@ final class AvatarTest extends TestCase
     #[Test]
     public function createWithGdConfiguration(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = ImageDriver::GD;
+        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = ImageDriver::GD->value;
+
+        $avatar = Avatar::create(name: 'John Doe');
+
+        self::assertInstanceOf(Gd::class, $avatar);
+    }
+
+    #[Test]
+    public function createResolvesGraphicsMagickStringFromGfxProcessor(): void
+    {
+        if (!class_exists(\Gmagick::class)) {
+            self::markTestSkipped('ext-gmagick is not available.');
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'GraphicsMagick';
+
+        $avatar = Avatar::create(name: 'John Doe');
+
+        self::assertInstanceOf(Gmagick::class, $avatar);
+    }
+
+    #[Test]
+    public function createResolvesImageMagickStringFromGfxProcessor(): void
+    {
+        if (!class_exists(\Imagick::class)) {
+            self::markTestSkipped('ext-imagick is not available.');
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'ImageMagick';
+
+        $avatar = Avatar::create(name: 'John Doe');
+
+        self::assertInstanceOf(Imagick::class, $avatar);
+    }
+
+    #[Test]
+    public function createFallsBackToGdWhenNoImageExtensionAvailable(): void
+    {
+        if (class_exists(\Imagick::class) || class_exists(\Gmagick::class)) {
+            self::markTestSkipped('Imagick or Gmagick is loaded; cannot test GD fallback.');
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'GraphicsMagick';
 
         $avatar = Avatar::create(name: 'John Doe');
 
@@ -113,13 +171,12 @@ final class AvatarTest extends TestCase
     }
 
     #[Test]
-    public function createFallsBackToImagickForUnknownDriver(): void
+    public function createFallsBackToGdForUnknownProcessor(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'unknown_processor';
 
         $avatar = Avatar::create(name: 'John Doe');
 
-        // Should fall back to Imagick (default case)
-        self::assertInstanceOf(Imagick::class, $avatar);
+        self::assertInstanceOf(Gd::class, $avatar);
     }
 }


### PR DESCRIPTION
## Summary

- Fix `Avatar::create()` match expression that always fell through to the Imagick default because it strict-compared a string against `ImageDriver` enum cases
- Convert `$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor']` string via `ImageDriver::tryFrom()` so users with `processor='GraphicsMagick'` (or any other valid value) hit the correct driver
- Fall back to the GD driver when the requested PHP extension (Imagick/Gmagick) is not loaded — prevents the `Class "Imagick" not found` fatal error reported in #57

## Changes

- `Classes/Image/Avatar.php` — string→enum conversion via `tryFrom`, simplified match with `class_exists` fallback to GD
- `Tests/Unit/Image/AvatarTest.php` — adapted tests to use real TYPO3 string values, added regression tests for the GraphicsMagick/ImageMagick string scenarios and the GD fallback path; guarded driver-specific tests with extension availability skips

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of avatar creation when image processor configuration is missing or invalid.
  * Changed the fallback image processor from ImageMagick to GD when the requested processor is unavailable or not installed.

* **Tests**
  * Enhanced test coverage for image processor fallback scenarios and missing PHP extension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->