### PR TITLE
fix: center letters correctly across image drivers

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,8 +10,11 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.6"
-webimage_extra_packages: [libxml2-utils]
-#webimage_extra_packages: ["php${DDEV_PHP_VERSION}-gmagick", libxml2-utils]
+# php-gmagick and php-imagick conflict at the Debian package level
+# (php-gmagick declares Conflicts: php-imagick) — only one can be installed locally.
+# gmagick is picked so issue #57 can be reproduced locally; imagick rendering is
+# exercised in CI instead.
+webimage_extra_packages: [libxml2-utils, "php${DDEV_PHP_VERSION}-gmagick"]
 use_dns_when_possible: true
 corepack_enable: false
 hooks:

--- a/Classes/Image/Driver/Gd.php
+++ b/Classes/Image/Driver/Gd.php
@@ -91,7 +91,7 @@ class Gd extends AbstractImageProvider implements LetterAvatarInterface
         $fontSize = $this->size * $this->fontSize;
         $textBox = imagettfbbox($fontSize, 0, $fontPath, $text);
         $x = ($this->size - ($textBox[2] - $textBox[0])) / 2;
-        $y = ($this->size - ($textBox[5] - $textBox[1])) / 2 + $fontSize / 2;
+        $y = ($this->size - $textBox[5] - $textBox[1]) / 2;
         imagettftext($canvas, $fontSize, 0, (int) $x, (int) $y, $color, $fontPath, $text);
     }
 }

--- a/Classes/Image/Driver/Gmagick.php
+++ b/Classes/Image/Driver/Gmagick.php
@@ -100,7 +100,7 @@ class Gmagick extends AbstractImageProvider implements LetterAvatarInterface
 
         $metrics = $canvas->queryfontmetrics($draw, $text);
         $textX = ($this->size - $metrics['textWidth']) / 2;
-        $textY = ($this->size + $metrics['textHeight']) / 2;
+        $textY = ($this->size + $metrics['ascender'] + $metrics['descender']) / 2;
 
         $draw->annotate($textX, $textY, $text);
         $canvas->drawimage($draw);

--- a/Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php
+++ b/Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image\Rendering;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
+
+use function count;
+use function dirname;
+use function sprintf;
+
+/**
+ * AbstractRenderingTestCase.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+abstract class AbstractRenderingTestCase extends TestCase
+{
+    protected const SIZE = 100;
+    protected const TOLERANCE = 0.15;
+    protected const MIN_PIXELS = 50;
+
+    private static bool $environmentInitialized = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (self::$environmentInitialized) {
+            return;
+        }
+        $extensionRoot = dirname(__DIR__, 4);
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            false,
+            $extensionRoot,
+            $extensionRoot,
+            $extensionRoot.'/.Build/var',
+            $extensionRoot.'/.Build/var/config',
+            $extensionRoot.'/.Build/public/index.php',
+            'UNIX',
+        );
+        self::$environmentInitialized = true;
+    }
+
+    /**
+     * @return array<string, array{Shape}>
+     */
+    public static function shapeProvider(): array
+    {
+        return [
+            'circle' => [Shape::CIRCLE],
+            'square' => [Shape::SQUARE],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('shapeProvider')]
+    public function testLetterIsCentered(Shape $shape): void
+    {
+        $avatar = $this->createAvatar($shape);
+        $canvas = $avatar->generate();
+        $pixels = $this->extractForegroundPixels($canvas, self::SIZE);
+
+        $this->assertLetterIsPresent($pixels);
+        $this->assertLetterIsHorizontallyCentered($pixels, self::SIZE);
+        $this->assertLetterIsVerticallyCentered($pixels, self::SIZE);
+    }
+
+    protected static function fontPath(): string
+    {
+        return dirname(__DIR__, 4).'/Resources/Public/Fonts/NotoSans-Bold.ttf';
+    }
+
+    abstract protected function createAvatar(Shape $shape): AbstractImageProvider;
+
+    /**
+     * @return list<array{int, int}>
+     */
+    abstract protected function extractForegroundPixels(mixed $canvas, int $size): array;
+
+    /**
+     * @param list<array{int, int}> $pixels
+     */
+    protected function assertLetterIsPresent(array $pixels): void
+    {
+        self::assertGreaterThanOrEqual(
+            self::MIN_PIXELS,
+            count($pixels),
+            sprintf(
+                'Expected at least %d foreground pixels, got %d. The letter does not appear to have been drawn.',
+                self::MIN_PIXELS,
+                count($pixels),
+            ),
+        );
+    }
+
+    /**
+     * @param list<array{int, int}> $pixels
+     */
+    protected function assertLetterIsHorizontallyCentered(array $pixels, int $size): void
+    {
+        $xs = array_column($pixels, 0);
+        $centerX = (min($xs) + max($xs)) / 2;
+        $expected = $size / 2;
+        $toleranceAbs = $size * self::TOLERANCE;
+
+        self::assertLessThanOrEqual(
+            $toleranceAbs,
+            abs($centerX - $expected),
+            sprintf(
+                'Letter is not horizontally centered: bounding-box center X = %.1f, expected %.1f ± %.1f.',
+                $centerX,
+                $expected,
+                $toleranceAbs,
+            ),
+        );
+    }
+
+    /**
+     * @param list<array{int, int}> $pixels
+     */
+    protected function assertLetterIsVerticallyCentered(array $pixels, int $size): void
+    {
+        $ys = array_column($pixels, 1);
+        $centerY = (min($ys) + max($ys)) / 2;
+        $expected = $size / 2;
+        $toleranceAbs = $size * self::TOLERANCE;
+
+        self::assertLessThanOrEqual(
+            $toleranceAbs,
+            abs($centerY - $expected),
+            sprintf(
+                'Letter is not vertically centered: bounding-box center Y = %.1f, expected %.1f ± %.1f.',
+                $centerY,
+                $expected,
+                $toleranceAbs,
+            ),
+        );
+    }
+}

--- a/Tests/Unit/Image/Rendering/GdRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/GdRenderingTest.php
@@ -20,14 +20,12 @@ use KonradMichalik\Typo3LetterAvatar\Image\Driver\Gd;
 
 use function extension_loaded;
 
-
 /**
  * GdRenderingTest.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-
 final class GdRenderingTest extends AbstractRenderingTestCase
 {
     protected function setUp(): void

--- a/Tests/Unit/Image/Rendering/GdRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/GdRenderingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image\Rendering;
+
+use GdImage;
+use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use KonradMichalik\Typo3LetterAvatar\Image\Driver\Gd;
+
+use function extension_loaded;
+
+
+/**
+ * GdRenderingTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+
+final class GdRenderingTest extends AbstractRenderingTestCase
+{
+    protected function setUp(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd is not available.');
+        }
+    }
+
+    protected function createAvatar(Shape $shape): AbstractImageProvider
+    {
+        return new Gd(
+            name: 'John Doe',
+            size: self::SIZE,
+            fontPath: self::fontPath(),
+            foregroundColor: '#FFFFFF',
+            backgroundColor: '#000000',
+            shape: $shape,
+        );
+    }
+
+    /**
+     * @return list<array{int, int}>
+     */
+    protected function extractForegroundPixels(mixed $canvas, int $size): array
+    {
+        self::assertInstanceOf(GdImage::class, $canvas);
+
+        $pixels = [];
+        for ($y = 0; $y < $size; ++$y) {
+            for ($x = 0; $x < $size; ++$x) {
+                $rgb = imagecolorat($canvas, $x, $y);
+                $r = ($rgb >> 16) & 0xFF;
+                $g = ($rgb >> 8) & 0xFF;
+                $b = $rgb & 0xFF;
+                if ($r + $g + $b > 600) {
+                    $pixels[] = [$x, $y];
+                }
+            }
+        }
+
+        return $pixels;
+    }
+}

--- a/Tests/Unit/Image/Rendering/GmagickRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/GmagickRenderingTest.php
@@ -17,14 +17,12 @@ use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
 use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\Gmagick;
 
-
 /**
  * GmagickRenderingTest.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-
 final class GmagickRenderingTest extends AbstractRenderingTestCase
 {
     protected function setUp(): void

--- a/Tests/Unit/Image/Rendering/GmagickRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/GmagickRenderingTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image\Rendering;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use KonradMichalik\Typo3LetterAvatar\Image\Driver\Gmagick;
+
+
+/**
+ * GmagickRenderingTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+
+final class GmagickRenderingTest extends AbstractRenderingTestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(\Gmagick::class)) {
+            self::markTestSkipped('ext-gmagick is not available.');
+        }
+    }
+
+    protected function createAvatar(Shape $shape): AbstractImageProvider
+    {
+        return new Gmagick(
+            name: 'John Doe',
+            size: self::SIZE,
+            fontPath: self::fontPath(),
+            foregroundColor: '#FFFFFF',
+            backgroundColor: '#000000',
+            shape: $shape,
+        );
+    }
+
+    /**
+     * Gmagick exposes no per-pixel accessor, so we round-trip via PNG blob → GD.
+     *
+     * @return list<array{int, int}>
+     */
+    protected function extractForegroundPixels(mixed $canvas, int $size): array
+    {
+        self::assertInstanceOf(\Gmagick::class, $canvas);
+
+        $canvas->setimageformat('png');
+        $gd = imagecreatefromstring($canvas->getimageblob());
+        self::assertNotFalse($gd, 'Failed to decode Gmagick PNG blob via GD.');
+
+        $pixels = [];
+        for ($y = 0; $y < $size; ++$y) {
+            for ($x = 0; $x < $size; ++$x) {
+                $rgb = imagecolorat($gd, $x, $y);
+                $r = ($rgb >> 16) & 0xFF;
+                $g = ($rgb >> 8) & 0xFF;
+                $b = $rgb & 0xFF;
+                if ($r + $g + $b > 600) {
+                    $pixels[] = [$x, $y];
+                }
+            }
+        }
+
+        return $pixels;
+    }
+}

--- a/Tests/Unit/Image/Rendering/ImagickRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/ImagickRenderingTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image\Rendering;
+
+use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
+use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
+use KonradMichalik\Typo3LetterAvatar\Image\Driver\Imagick;
+
+
+/**
+ * ImagickRenderingTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+
+final class ImagickRenderingTest extends AbstractRenderingTestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(\Imagick::class)) {
+            self::markTestSkipped('ext-imagick is not available.');
+        }
+    }
+
+    protected function createAvatar(Shape $shape): AbstractImageProvider
+    {
+        return new Imagick(
+            name: 'John Doe',
+            size: self::SIZE,
+            fontPath: self::fontPath(),
+            foregroundColor: '#FFFFFF',
+            backgroundColor: '#000000',
+            shape: $shape,
+        );
+    }
+
+    /**
+     * @return list<array{int, int}>
+     */
+    protected function extractForegroundPixels(mixed $canvas, int $size): array
+    {
+        self::assertInstanceOf(\Imagick::class, $canvas);
+
+        $pixels = [];
+        for ($y = 0; $y < $size; ++$y) {
+            for ($x = 0; $x < $size; ++$x) {
+                $color = $canvas->getImagePixelColor($x, $y)->getColor();
+                $r = (int) ($color['r'] ?? 0);
+                $g = (int) ($color['g'] ?? 0);
+                $b = (int) ($color['b'] ?? 0);
+                if ($r + $g + $b > 600) {
+                    $pixels[] = [$x, $y];
+                }
+            }
+        }
+
+        return $pixels;
+    }
+}

--- a/Tests/Unit/Image/Rendering/ImagickRenderingTest.php
+++ b/Tests/Unit/Image/Rendering/ImagickRenderingTest.php
@@ -17,14 +17,12 @@ use KonradMichalik\Typo3LetterAvatar\Enum\Shape;
 use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\Imagick;
 
-
 /**
  * ImagickRenderingTest.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-
 final class ImagickRenderingTest extends AbstractRenderingTestCase
 {
     protected function setUp(): void

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
 			"KonradMichalik\\Typo3LetterAvatar\\": "Classes/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"KonradMichalik\\Typo3LetterAvatar\\Tests\\": "Tests/"
+		}
+	},
 	"config": {
 		"allow-plugins": {
 			"eliashaeussler/version-bumper": true,


### PR DESCRIPTION
## Summary

- Fix vertical letter positioning in Gd and Gmagick drivers — letters were rendered too low and obscured by TYPO3's backend user icon overlay (closes #57).
- Add pixel-probing rendering tests under `Tests/Unit/Image/Rendering/` to prevent regressions. Tests verify the rendered letter is horizontally and vertically centered within ±15% of the canvas centre, across both shapes (circle/square).
- Enable `ext-gmagick` in the local DDEV image so the regression test for #57 can be reproduced locally. `ext-imagick` is left unchanged (Debian declares the two packages mutually exclusive — imagick rendering is exercised in CI instead).

## Root cause

- **Gd**: `imagettfbbox` returns `textBox[5]` (upper-right y) as negative and `textBox[1]` (lower-left y) as positive. The previous formula `($size - ($textBox[5] - $textBox[1])) / 2 + $fontSize / 2` treated their difference as a positive text height, which pushed the baseline well below centre.
- **Gmagick**: the previous formula used the full `textHeight` metric, which equals the bounding-box height (positive). This effectively placed the baseline at the bottom of the bounding box, again pushing letters downward.

Both formulas now derive the baseline so the visual bounding box sits centred on the canvas.

## Changes

- `Classes/Image/Driver/Gd.php` — corrected baseline Y formula
- `Classes/Image/Driver/Gmagick.php` — baseline derived from `ascender + descender` instead of `textHeight`
- `Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php` — driver-agnostic pixel-probing assertions, font path helper, one-shot TYPO3 `Environment` bootstrap
- `Tests/Unit/Image/Rendering/GdRenderingTest.php` — Gd-specific pixel reader
- `Tests/Unit/Image/Rendering/ImagickRenderingTest.php` — Imagick-specific pixel reader (skips if `ext-imagick` missing)
- `Tests/Unit/Image/Rendering/GmagickRenderingTest.php` — Gmagick reader via PNG-blob round-trip (Gmagick has no per-pixel accessor)
- `composer.json` — added `autoload-dev` PSR-4 map for the `Tests/` namespace so the abstract base class can be loaded
- `.ddev/config.yaml` — added `php-gmagick` with a comment documenting the package-level conflict with `php-imagick`

## Test plan

- [x] `composer test` passes locally (`Tests: 133, Assertions: 284, Skipped: 6`) — skips are all `ext-imagick`-related
- [x] `composer cgl sca` clean
- [x] `composer cgl migration` clean (after one Rector auto-fix)
- [x] Gmagick rendering tests reproduce #57 on unfixed code (bbox centre Y ≈ 71 instead of 50) and pass after the fix
- [ ] CI matrix to confirm Imagick rendering remains correct