### PR TITLE
fix: use OpenSans-Bold as default font

### DIFF
--- a/Classes/Image/AbstractImageProvider.php
+++ b/Classes/Image/AbstractImageProvider.php
@@ -33,7 +33,7 @@ abstract class AbstractImageProvider
         public string $initials = '',
         public int $size = 100,
         public float|int $fontSize = 0.5,
-        public string $fontPath = 'EXT:'.Configuration::EXT_KEY.'/Resources/Public/Fonts/arial-bold.ttf',
+        public string $fontPath = 'EXT:'.Configuration::EXT_KEY.'/Resources/Public/Fonts/OpenSans-Bold.ttf',
         public string $foregroundColor = '',
         public string $backgroundColor = '',
         public ColorMode $mode = ColorMode::CUSTOM,


### PR DESCRIPTION
## Summary

- Update the default `fontPath` in `AbstractImageProvider` to point to `OpenSans-Bold.ttf`, which actually ships with the extension. The previous default referenced `arial-bold.ttf`, which was removed in commit `905a12b` ("add font selection options") together with `arial.ttf` — presumably for licensing reasons — but the constructor default was never updated. As a result, every avatar rendered without an explicit `fontPath` override hit a non-existent file.

## Changes

- `Classes/Image/AbstractImageProvider.php` — default `fontPath` now points to `OpenSans-Bold.ttf`

## Test plan

- [x] `composer test` passes (`Tests: 133, Assertions: 284, Skipped: 6`)
- [x] `Resources/Public/Fonts/OpenSans-Bold.ttf` confirmed present in the repo
- [x] Only one occurrence of `arial-bold` existed in `Classes/` / `Configuration/` / `Resources/Private/` — fully replaced