### PR TITLE
fix: pin Renovate PHP constraint to 8.2 to match composer platform

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 		"package-lock.json"
 	],
 	"constraints": {
-		"php": ">=8.2"
+		"php": "8.2"
 	},
 	"packageRules": [
 		{


### PR DESCRIPTION
## Summary

- Align Renovate's PHP resolution with the `config.platform.php: "8.2"` setting in `composer.json`
- Prevents Renovate from proposing dependency updates that require PHP > 8.2 (e.g. PHPUnit 12 → PHP >=8.3, symfony/string v8.1 → PHP >=8.4.1), which would otherwise break CI when composer resolves against the locked platform version

## Changes

- `renovate.json` — change `constraints.php` from `">=8.2"` to `"8.2"` so Renovate resolves package versions against PHP 8.2 exactly, instead of treating any PHP ≥ 8.2 as acceptable