### PR TITLE
fix: use range constraint for Renovate PHP version to fix install-tool

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 		"package-lock.json"
 	],
 	"constraints": {
-		"php": "8.2"
+		"php": "~8.2.0"
 	},
 	"packageRules": [
 		{


### PR DESCRIPTION
## Summary

Follow-up to #71. The single-version value `"8.2"` caused Renovate's containerbase `install-tool php 8.2` step to fail when refreshing lock files (see PR #61 artifact-update error), because the install-tool catalog expects a resolvable semver range — not a free-standing major.minor literal.

Switching to `"~8.2.0"` (= `>=8.2.0, <8.3.0`) satisfies both consumers of the constraint:

- **Renovate's `install-tool`** — resolves the range to the highest available 8.2.x patch and installs it
- **Composer** — treats it as strictly 8.2.x, so packages requiring PHP 8.3+ (phpunit 12, symfony/string v8.1, …) stay out of the lock file, matching the `config.platform.php: "8.2"` setting in `composer.json`

After merge, existing Renovate PRs (e.g. #61) need a rebase/retry tick to re-run the artifact update with the new constraint.

## Changes

- `renovate.json` — change `constraints.php` from `"8.2"` to `"~8.2.0"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP version constraint configuration for stricter dependency evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konradmichalik/typo3-letter-avatar/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->