### PR TITLE
fix: stop Renovate from ignoring platform.php during composer updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
 	"ignorePaths": [
 		"package-lock.json"
 	],
+	"composerIgnorePlatformReqs": ["ext-*", "lib-*"],
 	"constraints": {
 		"php": "~8.2.0"
 	},


### PR DESCRIPTION
## Summary

Root cause for the PR #61 lockfile-maintenance failure: the extended preset `konradmichalik/renovate-config:typo3-extension` sets `composerIgnorePlatformReqs: ["ext-*", "lib-*", "php"]`, which makes Renovate pass `--ignore-platform-req=php` to composer. With that flag, composer ignores `config.platform.php: "8.2"` from `composer.json` during resolution and picks the latest available version of every package — pulling in phpunit `13.1.13` (requires PHP ≥8.4.1) and symfony/string `v8.1.0` (requires PHP ≥8.4.1) on a project whose declared minimum is PHP 8.2.

The `constraints.php` value only controls which PHP version is installed in Renovate's runner container — not which version composer's resolver enforces. The actual platform constraint must come from `composerIgnorePlatformReqs` not containing `"php"`.

This PR overrides the preset locally so php platform reqs are respected again. Renovate's default `["ext-*", "lib-*"]` is the right value here.

## Effect after merge

- Lockfile maintenance and other composer artifact updates run with `--ignore-platform-req=ext-* --ignore-platform-req=lib-*` only
- composer respects `config.platform.php: "8.2"` → phpunit pins to `^11.x`, symfony/string to `^7.x`
- PR #61 needs a rebase/retry tick afterwards to regenerate its lockfile with the corrected behavior

## Follow-up (separate repo)

The `"php"` entry in `composerIgnorePlatformReqs` should be dropped from `konradmichalik/renovate-config:typo3-extension` — it silently neutralises `constraints.php` for every project that extends the preset.

## Changes

- `renovate.json` — add `composerIgnorePlatformReqs: ["ext-*", "lib-*"]` to override the preset's `[…, "php"]` value