### PR TITLE
chore: drop renovate.json overrides now covered by shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
 	"ignorePaths": [
 		"package-lock.json"
 	],
-	"composerIgnorePlatformReqs": ["ext-*", "lib-*"],
-	"constraints": {
-		"php": "~8.2.0"
-	},
 	"packageRules": [
 		{
 			"matchPackageNames": ["php"],


### PR DESCRIPTION
## Summary

After updating the shared `konradmichalik/renovate-config:typo3-extension` preset (now ships `composerIgnorePlatformReqs: ["ext-intl"]` and `constraints.php: "~8.2.0"`), the local overrides for these two fields in this repo are redundant:

- `composerIgnorePlatformReqs: ["ext-*", "lib-*"]` was added in #73 as a workaround for the preset's previous `[…, "php"]` value. With `"php"` no longer in the preset list, the local override is no longer needed — and dropping it lets the preset's narrower `["ext-intl"]` apply, which surfaces missing platform extensions instead of silently ignoring them.
- `constraints.php: "~8.2.0"` is identical to what the preset now provides.

Keeping locally only what is actually project-specific: `extends`, `ignorePaths`, and the `php` package rule (disables PHP-version PRs in favour of widening managed via the base preset).

## Changes

- `renovate.json` — remove `composerIgnorePlatformReqs` and `constraints` blocks (both fully covered by the extended preset)