### PR TITLE
ci: switch release workflow to konradmichalik/reusable-github-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ter-publish:
-    uses: maikschneider/reusable-workflows/.github/workflows/release.yml@main
+    uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

- Point the release workflow at `konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml` instead of `maikschneider/reusable-workflows`
- Brings the TER publish step under the same reusable-workflows repo used for the other CI pieces

## Changes

- `.github/workflows/release.yml` — update `uses:` reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use a new action for the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->