### PR TITLE
refactor: derive stringify color via php-color package

### DIFF
--- a/Classes/Service/Colorize.php
+++ b/Classes/Service/Colorize.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Service;
 
+use KonradMichalik\Color\ColorHasher;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\ColorMode;
 use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
 use KonradMichalik\Typo3LetterAvatar\Utility\{ConfigurationUtility, StringUtility};
-
-use function sprintf;
 
 /**
  * Colorize.
@@ -47,9 +46,9 @@ class Colorize
     {
         return match ($this->avatar->mode) {
             ColorMode::CUSTOM => $this->avatar->backgroundColor,
-            ColorMode::STRINGIFY => $this->stringToColor(
+            ColorMode::STRINGIFY => ColorHasher::crc32()->hash(
                 StringUtility::resolveInitials($this->avatar->name, $this->avatar->initials, $this->avatar->transform),
-            ),
+            )->scaleRgb(0.5)->toHex(),
             ColorMode::RANDOM => $this->getRandomBackgroundColor(),
             ColorMode::THEME, ColorMode::BACKEND_THEME => $this->getRandomThemeBackendColor(),
             ColorMode::PAIRS => $this->getPairBackgroundColor(),
@@ -130,18 +129,6 @@ class Colorize
                 $this->backgroundColors = [...$this->backgroundColors, ...($themeConfig['backgrounds'] ?? [])];
             }
         }
-    }
-
-    private function stringToColor(string $string): string
-    {
-        $rgb = substr(hash('crc32b', $string), 0, 6);
-
-        return sprintf(
-            '#%02X%02X%02X',
-            hexdec(substr($rgb, 0, 2)) / 2,
-            hexdec(substr($rgb, 2, 2)) / 2,
-            hexdec(substr($rgb, 4, 2)) / 2,
-        );
     }
 
     private function getRandomConfig(): array

--- a/Tests/Unit/Service/ColorizeTest.php
+++ b/Tests/Unit/Service/ColorizeTest.php
@@ -282,9 +282,11 @@ final class ColorizeTest extends TestCase
     }
 
     #[Test]
-    public function resolveBackgroundColorWithStringifyDarkensColorByHalving(): void
+    public function resolveBackgroundColorWithStringifyDarkensColorViaRgbHalving(): void
     {
-        // The implementation halves each RGB component (hexdec/2). Verify each channel is in [0, 127].
+        // STRINGIFY hashes the resolved initials with crc32 and halves each RGB
+        // channel (php-color scaleRgb(0.5)) for a darker background. Deterministic:
+        // initials 'JD' -> crc32 #fe30f9 -> halved #7f187d.
         $this->avatarProvider->mode = ColorMode::STRINGIFY;
         $this->avatarProvider->name = 'John Doe';
         $this->avatarProvider->initials = '';
@@ -292,14 +294,7 @@ final class ColorizeTest extends TestCase
 
         $color = $this->colorizeService->resolveBackgroundColor();
 
-        self::assertSame('#', $color[0]);
-        $r = hexdec(substr($color, 1, 2));
-        $g = hexdec(substr($color, 3, 2));
-        $b = hexdec(substr($color, 5, 2));
-
-        self::assertLessThanOrEqual(127, $r);
-        self::assertLessThanOrEqual(127, $g);
-        self::assertLessThanOrEqual(127, $b);
+        self::assertSame('#7f187d', $color);
     }
 
     #[Test]

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 	"require": {
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-mbstring": "*",
+		"konradmichalik/php-color": "^0.2.0",
 		"symfony/console": "^7.0 || ^8.0",
 		"typo3/cms-backend": "^13.4 || ^14.0",
 		"typo3/cms-core": "^13.4 || ^14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37953312c174bf5bcd5577ac97ddbb99",
+    "content-hash": "0b682dac5c04986e18aaa116d953207c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -984,6 +984,66 @@
                 }
             ],
             "time": "2026-06-02T12:30:48+00:00"
+        },
+        {
+            "name": "konradmichalik/php-color",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/konradmichalik/php-color.git",
+                "reference": "ce53155e764e7c7e82cf79da8d685f56f3553139"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/konradmichalik/php-color/zipball/ce53155e764e7c7e82cf79da8d685f56f3553139",
+                "reference": "ce53155e764e7c7e82cf79da8d685f56f3553139",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^2.0",
+                "ergebnis/composer-normalize": "^2.42",
+                "konradmichalik/php-cs-fixer-preset": "^0.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^12.0",
+                "rector/rector": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "KonradMichalik\\Color\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Konrad Michalik",
+                    "email": "hej@konradmichalik.dev",
+                    "homepage": "https://konradmichalik.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A small, framework-agnostic PHP library for color conversion, luminance, contrast and deterministic string-to-color hashing.",
+            "keywords": [
+                "color",
+                "contrast",
+                "hex",
+                "hsl",
+                "luminance",
+                "rgb",
+                "wcag"
+            ],
+            "support": {
+                "issues": "https://github.com/konradmichalik/php-color/issues",
+                "source": "https://github.com/konradmichalik/php-color/tree/0.2.0"
+            },
+            "time": "2026-06-19T11:30:22+00:00"
         },
         {
             "name": "lolli42/finediff",


### PR DESCRIPTION
## Summary

- Replace the inline CRC32 color math in `Colorize` with the dedicated `konradmichalik/php-color` package
- STRINGIFY backgrounds are now derived via `ColorHasher::crc32()->hash()->scaleRgb(0.5)`, keeping the RGB-halving (darkening) behaviour through the package's new `scaleRgb()` API
- Note: STRINGIFY colors shift once (the package selects the low CRC32 bytes vs. the previous high bytes); already-rendered avatars stay cached until cleared via `ClearAvatarsCommand`

## Changes

- `composer.json` / `composer.lock` - Add `konradmichalik/php-color: ^0.2.0`
- `Classes/Service/Colorize.php` - Drop the private `stringToColor()` helper; resolve STRINGIFY backgrounds through the package API
- `Tests/Unit/Service/ColorizeTest.php` - Replace the channel-bound darkening test with a deterministic regression assertion (`JD` → `#fe30f9` → `#7f187d`)