### PR TITLE
chore: prefix package description with extension name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "konradmichalik/typo3-letter-avatar",
-	"description": "TYPO3 extension, which generates colorful backend user avatars using name initials letter.",
+	"description": "Letter Avatar - TYPO3 extension, which generates colorful backend user avatars using name initials letter.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
## Summary

- Prefix the composer package description with "Letter Avatar - " for clearer identification in package listings

## Changes

- `composer.json` - Update `description` field