### PR TITLE
fix: read colorMode config key and validate enum arguments in ViewHelper

### DIFF
--- a/Classes/ViewHelpers/AvatarViewHelper.php
+++ b/Classes/ViewHelpers/AvatarViewHelper.php
@@ -13,11 +13,15 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\ViewHelpers;
 
+use BackedEnum;
 use InvalidArgumentException;
 use KonradMichalik\Typo3LetterAvatar\Enum\{ColorMode, ImageFormat, Shape, Transform};
 use KonradMichalik\Typo3LetterAvatar\Image\Avatar;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+use function is_string;
+use function sprintf;
 
 /**
  * AvatarViewHelper.
@@ -109,18 +113,21 @@ class AvatarViewHelper extends AbstractViewHelper
             throw new InvalidArgumentException('Either name or initials must be provided', 1204028706);
         }
 
-        $configuration = [
+        // Omit unresolved (null) values so the Avatar constructor defaults apply.
+        $configuration = array_filter([
             'name' => $this->arguments['name'] ?? '',
             'initials' => $this->arguments['initials'] ?? '',
-            'mode' => (isset($this->arguments['mode']) && '' !== $this->arguments['mode']) ? ColorMode::tryFrom($this->arguments['mode']) : ConfigurationUtility::get('mode', ColorMode::class),
+            'mode' => $this->resolveEnumArgument('mode', ColorMode::class, 'colorMode'),
             'theme' => $this->arguments['theme'] ?? ConfigurationUtility::get('theme'),
             'size' => $this->arguments['size'] ?? ConfigurationUtility::get('size'),
             'fontSize' => $this->arguments['fontSize'] ?? ConfigurationUtility::get('fontSize'),
             'fontPath' => $this->arguments['fontPath'] ?? ConfigurationUtility::get('fontPath'),
-            'imageFormat' => (isset($this->arguments['imageFormat']) && '' !== $this->arguments['imageFormat']) ? ImageFormat::tryFrom($this->arguments['imageFormat']) : ConfigurationUtility::get('imageFormat', ImageFormat::class),
-            'transform' => (isset($this->arguments['transform']) && '' !== $this->arguments['transform']) ? Transform::tryFrom($this->arguments['transform']) : ConfigurationUtility::get('transform', Transform::class),
-            'shape' => (isset($this->arguments['shape']) && '' !== $this->arguments['shape']) ? Shape::tryFrom($this->arguments['shape']) : ConfigurationUtility::get('shape', Shape::class),
-        ];
+            'foregroundColor' => $this->arguments['foregroundColor'] ?? null,
+            'backgroundColor' => $this->arguments['backgroundColor'] ?? null,
+            'imageFormat' => $this->resolveEnumArgument('imageFormat', ImageFormat::class, 'imageFormat'),
+            'transform' => $this->resolveEnumArgument('transform', Transform::class, 'transform'),
+            'shape' => $this->resolveEnumArgument('shape', Shape::class, 'shape'),
+        ], static fn (mixed $value): bool => null !== $value);
 
         $avatarService = Avatar::create(...$configuration);
 
@@ -129,5 +136,25 @@ class AvatarViewHelper extends AbstractViewHelper
         }
 
         return $avatarService->getWebPath();
+    }
+
+    /**
+     * @template T of BackedEnum
+     *
+     * @param class-string<T> $enumClass
+     *
+     * @return T|null
+     */
+    private function resolveEnumArgument(string $argument, string $enumClass, string $configurationKey): ?BackedEnum
+    {
+        $value = $this->arguments[$argument] ?? '';
+
+        if (is_string($value) && '' !== $value) {
+            return $enumClass::tryFrom($value) ?? throw new InvalidArgumentException(sprintf('Invalid value "%s" for avatar argument "%s".', $value, $argument), 1751719200);
+        }
+
+        $configured = ConfigurationUtility::get($configurationKey, $enumClass);
+
+        return $configured instanceof $enumClass ? $configured : null;
     }
 }

--- a/Tests/CGL/phpstan-baseline.neon
+++ b/Tests/CGL/phpstan-baseline.neon
@@ -251,9 +251,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../../Classes/Utility/StringUtility.php
-
-		-
-			message: '#^Cognitive complexity for "KonradMichalik\\Typo3LetterAvatar\\ViewHelpers\\AvatarViewHelper\:\:render\(\)" is 11, keep it under 10$#'
-			identifier: complexity.functionLike
-			count: 1
-			path: ../../Classes/ViewHelpers/AvatarViewHelper.php

--- a/Tests/Unit/ViewHelpers/AvatarViewHelperRenderTest.php
+++ b/Tests/Unit/ViewHelpers/AvatarViewHelperRenderTest.php
@@ -64,6 +64,7 @@ final class AvatarViewHelperRenderTest extends TestCase
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'] = '2775';
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask'] = '0664';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key';
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [
             'colorMode' => 'stringify',
@@ -98,6 +99,7 @@ final class AvatarViewHelperRenderTest extends TestCase
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'],
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask'],
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],
         );
 
         GeneralUtility::rmdir(Environment::getPublicPath().self::IMAGE_PATH, true);

--- a/Tests/Unit/ViewHelpers/AvatarViewHelperRenderTest.php
+++ b/Tests/Unit/ViewHelpers/AvatarViewHelperRenderTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\ViewHelpers;
+
+use InvalidArgumentException;
+use KonradMichalik\Typo3LetterAvatar\Configuration;
+use KonradMichalik\Typo3LetterAvatar\Enum\{ImageFormat, Shape, Transform};
+use KonradMichalik\Typo3LetterAvatar\ViewHelpers\AvatarViewHelper;
+use PHPUnit\Framework\Attributes\{DataProvider, Test};
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+use function dirname;
+use function extension_loaded;
+
+/**
+ * AvatarViewHelperRenderTest.
+ *
+ * Functional render() tests covering configuration fallbacks and
+ * argument validation of the AvatarViewHelper.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class AvatarViewHelperRenderTest extends TestCase
+{
+    private const IMAGE_PATH = '/.Build/var/tests/avatars/';
+
+    public static function setUpBeforeClass(): void
+    {
+        $extensionRoot = dirname(__DIR__, 3);
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            false,
+            $extensionRoot,
+            $extensionRoot,
+            $extensionRoot.'/.Build/var',
+            $extensionRoot.'/.Build/var/config',
+            $extensionRoot.'/.Build/public/index.php',
+            'UNIX',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('gd')) {
+            self::markTestSkipped('ext-gd is not available.');
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'] = '2775';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask'] = '0664';
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [
+            'colorMode' => 'stringify',
+            'theme' => 'colorful',
+            'fontPath' => dirname(__DIR__, 3).'/Resources/Public/Fonts/NotoSans-Bold.ttf',
+        ];
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
+            'size' => 50,
+            'fontSize' => 0.5,
+            'imagePath' => self::IMAGE_PATH,
+            'imageFormat' => ImageFormat::PNG,
+            'shape' => Shape::CIRCLE,
+            'transform' => Transform::NONE,
+            'random' => [
+                'foregrounds' => ['#FFFFFF'],
+                'backgrounds' => ['#FF0000', '#00FF00'],
+            ],
+            'themes' => [
+                'colorful' => [
+                    'foregrounds' => ['#FFFFFF'],
+                    'backgrounds' => ['#2196F3'],
+                ],
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'],
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask'],
+        );
+
+        GeneralUtility::rmdir(Environment::getPublicPath().self::IMAGE_PATH, true);
+    }
+
+    #[Test]
+    public function renderFallsBackToConfiguredColorModeWhenModeArgumentIsMissing(): void
+    {
+        $webPath = $this->render(['name' => 'John Doe']);
+
+        self::assertStringEndsWith('.png', $webPath);
+        self::assertFileExists(Environment::getPublicPath().$webPath);
+    }
+
+    #[Test]
+    public function renderPassesForegroundAndBackgroundColorArguments(): void
+    {
+        $webPath = $this->render([
+            'name' => 'John Doe',
+            'mode' => 'custom',
+            'foregroundColor' => '#000000',
+            'backgroundColor' => '#FFFFFF',
+        ]);
+
+        self::assertFileExists(Environment::getPublicPath().$webPath);
+    }
+
+    #[Test]
+    public function renderAppliesShapeAndTransformArguments(): void
+    {
+        $webPath = $this->render([
+            'initials' => 'jd',
+            'shape' => 'square',
+            'transform' => 'uppercase',
+        ]);
+
+        self::assertFileExists(Environment::getPublicPath().$webPath);
+    }
+
+    #[Test]
+    public function renderReusesExistingAvatarFile(): void
+    {
+        $webPath = $this->render(['name' => 'John Doe']);
+        $file = Environment::getPublicPath().$webPath;
+        $firstModificationTime = filemtime($file);
+
+        self::assertSame($webPath, $this->render(['name' => 'John Doe']));
+        self::assertSame($firstModificationTime, filemtime($file));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function invalidEnumArgumentProvider(): array
+    {
+        return [
+            'mode' => ['mode', 'nonsense'],
+            'imageFormat' => ['imageFormat', 'gif'],
+            'transform' => ['transform', 'capitalize'],
+            'shape' => ['shape', 'triangle'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidEnumArgumentProvider')]
+    public function renderThrowsExceptionForInvalidEnumArgument(string $argument, string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1751719200);
+
+        $this->render(['name' => 'John Doe', $argument => $value]);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function render(array $arguments): string
+    {
+        $viewHelper = new AvatarViewHelper();
+        $viewHelper->initializeArguments();
+
+        $argumentsProperty = new ReflectionProperty(AbstractViewHelper::class, 'arguments');
+        $argumentsProperty->setValue($viewHelper, $arguments);
+
+        return $viewHelper->render();
+    }
+}


### PR DESCRIPTION
## Summary

- Fix the `AvatarViewHelper` reading a non-existent `mode` configuration key instead of `colorMode`, which caused a `TypeError` on the documented minimal usage (`{letter:avatar(name: 'John Doe')}`) whenever no explicit `mode` argument was passed.
- Pass through the already-registered `foregroundColor` / `backgroundColor` arguments, which were previously dead (registered but never forwarded to `Avatar::create()`).
- Validate enum arguments (`mode`, `imageFormat`, `transform`, `shape`): invalid values now throw a clear `InvalidArgumentException` instead of silently producing `null` and a downstream `TypeError`.

## Changes

- `Classes/ViewHelpers/AvatarViewHelper.php` — read `colorMode`, forward color arguments, extract enum resolution into `resolveEnumArgument()` (collapses four near-identical ternaries), add validation.
- `Tests/Unit/ViewHelpers/AvatarViewHelperRenderTest.php` — new functional `render()` tests covering config fallback, color/shape/transform arguments, file reuse, and invalid-enum rejection.
- `Tests/CGL/phpstan-baseline.neon` — drop the now-obsolete cognitive-complexity baseline entry for `render()`.