### PR TITLE
fix: apply avatar configuration changes made by event listeners

### DIFF
--- a/Classes/AvatarProvider/LetterAvatarProvider.php
+++ b/Classes/AvatarProvider/LetterAvatarProvider.php
@@ -19,9 +19,9 @@ use KonradMichalik\Typo3LetterAvatar\Event\BackendUserAvatarConfigurationEvent;
 use KonradMichalik\Typo3LetterAvatar\Image\Avatar;
 use KonradMichalik\Typo3LetterAvatar\Service\BackendThemeResolver;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Backend\Avatar\{AvatarProviderInterface, Image};
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 use function is_array;
@@ -35,9 +35,36 @@ use function is_string;
  */
 class LetterAvatarProvider implements AvatarProviderInterface
 {
-    public function __construct(protected readonly EventDispatcher $eventDispatcher) {}
+    public function __construct(protected readonly EventDispatcherInterface $eventDispatcher) {}
 
     public function getImage(array $backendUser, $size): ?Image
+    {
+        $configuration = $this->resolveConfiguration($backendUser);
+        $avatarService = Avatar::create(...$configuration);
+
+        if (!file_exists($avatarService->getImagePath())) {
+            $avatarService->save();
+        }
+
+        $imageSize = ConfigurationUtility::get('size');
+
+        return GeneralUtility::makeInstance(
+            Image::class,
+            $avatarService->getWebPath(),
+            $imageSize,
+            $imageSize,
+        );
+    }
+
+    /**
+     * Builds the avatar configuration for a backend user and lets listeners
+     * override it via the PSR-14 event before it is applied.
+     *
+     * @param array<string, mixed> $backendUser
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveConfiguration(array $backendUser): array
     {
         $mode = ConfigurationUtility::get('colorMode', ColorMode::class);
         if (!$mode instanceof ColorMode) {
@@ -56,19 +83,10 @@ class LetterAvatarProvider implements AvatarProviderInterface
             'shape' => ConfigurationUtility::get('shape', Shape::class),
         ];
 
-        $this->eventDispatcher->dispatch(new BackendUserAvatarConfigurationEvent($backendUser, $configuration));
-        $avatarService = Avatar::create(...$configuration);
+        $event = new BackendUserAvatarConfigurationEvent($backendUser, $configuration);
+        $this->eventDispatcher->dispatch($event);
 
-        if (!file_exists($avatarService->getImagePath())) {
-            $avatarService->save();
-        }
-
-        return GeneralUtility::makeInstance(
-            Image::class,
-            $avatarService->getWebPath(),
-            ConfigurationUtility::get('size'),
-            ConfigurationUtility::get('size'),
-        );
+        return $event->getConfiguration();
     }
 
     private function getName(array $backendUser): string

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -77,8 +77,8 @@ class ModifyLetterAvatarEventListener
         if ($backendUser['admin'] === 1) {
             $configuration = $event->getConfiguration();
             $configuration['mode'] = ColorMode::CUSTOM;
-            $configuration['foreground'] = '#000000';
-            $configuration['background'] = '#FFFFFF';
+            $configuration['foregroundColor'] = '#000000';
+            $configuration['backgroundColor'] = '#FFFFFF';
             
             $event->setConfiguration($configuration);
         }

--- a/Tests/Unit/AvatarProvider/LetterAvatarProviderConfigurationTest.php
+++ b/Tests/Unit/AvatarProvider/LetterAvatarProviderConfigurationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\AvatarProvider;
+
+use KonradMichalik\Typo3LetterAvatar\AvatarProvider\LetterAvatarProvider;
+use KonradMichalik\Typo3LetterAvatar\Configuration;
+use KonradMichalik\Typo3LetterAvatar\Enum\ColorMode;
+use KonradMichalik\Typo3LetterAvatar\Event\BackendUserAvatarConfigurationEvent;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use ReflectionMethod;
+
+/**
+ * LetterAvatarProviderConfigurationTest.
+ *
+ * Verifies that the provider resolves the avatar configuration from the
+ * extension settings and honours modifications made by event listeners.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class LetterAvatarProviderConfigurationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [
+            'colorMode' => 'stringify',
+            'theme' => 'colorful',
+            'prioritizeRealName' => true,
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
+            'size' => 50,
+            'fontSize' => 0.5,
+            'fontPath' => 'EXT:typo3_letter_avatar/Resources/Public/Fonts/OpenSans-Bold.ttf',
+            'imageFormat' => 'png',
+            'transform' => 'none',
+            'shape' => 'circle',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
+        );
+    }
+
+    #[Test]
+    public function resolveConfigurationBuildsConfigurationFromExtensionSettings(): void
+    {
+        $configuration = $this->resolveConfiguration(
+            $this->dispatcherWithoutListener(),
+            ['username' => 'admin', 'realName' => 'Ada Lovelace'],
+        );
+
+        self::assertSame('Ada Lovelace', $configuration['name']);
+        self::assertSame(ColorMode::STRINGIFY, $configuration['mode']);
+        self::assertSame(50, $configuration['size']);
+    }
+
+    #[Test]
+    public function resolveConfigurationAppliesListenerModifications(): void
+    {
+        $dispatcher = new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                if ($event instanceof BackendUserAvatarConfigurationEvent) {
+                    $configuration = $event->getConfiguration();
+                    $configuration['mode'] = ColorMode::CUSTOM;
+                    $configuration['foregroundColor'] = '#000000';
+                    $configuration['backgroundColor'] = '#FFFFFF';
+                    $event->setConfiguration($configuration);
+                }
+
+                return $event;
+            }
+        };
+
+        $configuration = $this->resolveConfiguration($dispatcher, ['username' => 'admin']);
+
+        self::assertSame(ColorMode::CUSTOM, $configuration['mode']);
+        self::assertSame('#000000', $configuration['foregroundColor']);
+        self::assertSame('#FFFFFF', $configuration['backgroundColor']);
+    }
+
+    private function dispatcherWithoutListener(): EventDispatcherInterface
+    {
+        return new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                return $event;
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $backendUser
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveConfiguration(EventDispatcherInterface $dispatcher, array $backendUser): array
+    {
+        $provider = new LetterAvatarProvider($dispatcher);
+        $method = new ReflectionMethod($provider, 'resolveConfiguration');
+
+        return $method->invoke($provider, $backendUser);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-mbstring": "*",
 		"konradmichalik/php-color": "^0.2.0",
+		"psr/event-dispatcher": "^1.0",
 		"symfony/console": "^7.0 || ^8.0",
 		"typo3/cms-backend": "^13.4 || ^14.0",
 		"typo3/cms-core": "^13.4 || ^14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8600eb7090ee41b936853acc0a1a9a9",
+    "content-hash": "f9d2d2767928e4f01ca93175d6281890",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

- Fix the `BackendUserAvatarConfigurationEvent` being dispatched but its result discarded, so anything a listener changed via `setConfiguration()` was silently ignored. The provider now applies `$event->getConfiguration()`.
- Depend on the PSR-14 `EventDispatcherInterface` instead of the concrete TYPO3 `EventDispatcher` (depend on the abstraction; also makes the event contract unit-testable).
- Correct the documented listener example, which used the non-existent `foreground` / `background` keys instead of the actual `foregroundColor` / `backgroundColor` constructor parameters.

## Changes

- `Classes/AvatarProvider/LetterAvatarProvider.php` — apply the event result, extract `resolveConfiguration()`, switch to the PSR interface, deduplicate the repeated `size` lookup.
- `Documentation/Usage.md` — fix the listener example configuration keys.
- `Tests/Unit/AvatarProvider/LetterAvatarProviderConfigurationTest.php` — new tests asserting the config is built from extension settings and that listener modifications are honoured.