### PR TITLE
fix: delete only avatar files and guard the image path in avatar:clear

### DIFF
--- a/Classes/Command/ClearAvatarsCommand.php
+++ b/Classes/Command/ClearAvatarsCommand.php
@@ -17,9 +17,10 @@ use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\{InputInterface, InputOption};
 use Symfony\Component\Console\Output\OutputInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Core\Environment;
 
 use function count;
+use function sprintf;
 
 /**
  * ClearAvatarsCommand.
@@ -45,28 +46,70 @@ final class ClearAvatarsCommand extends Command
         $path = PathUtility::getImageFolder();
         $output->writeln("🧽 - Clearing all generated letter avatars in <question>$path</question>");
 
-        $imageCount = 0;
-        if (is_dir($path)) {
-            $files = scandir($path);
-            $imageCount = count(array_filter($files, static fn (string $file): bool => is_file($path.\DIRECTORY_SEPARATOR.$file) && 1 === preg_match('/\.(png|jpg|jpeg)$/i', $file)));
+        if (!$this->isSafeAvatarPath($path)) {
+            $output->writeln('❌ - Refusing to clear: the configured image path is invalid or points to the site root.');
+
+            return Command::FAILURE;
         }
 
+        $avatarFiles = $this->findAvatarFiles($path);
+
         if ((bool) $input->getOption('dry-run')) {
-            $output->writeln("ℹ️ - <comment>$imageCount</comment> letter avatars would be cleared (dry-run).");
+            $output->writeln(sprintf('ℹ️ - <comment>%d</comment> letter avatars would be cleared (dry-run).', count($avatarFiles)));
 
             return Command::SUCCESS;
         }
 
-        $return = GeneralUtility::rmdir($path, true);
+        $deleted = 0;
+        foreach ($avatarFiles as $file) {
+            if (@unlink($file)) {
+                ++$deleted;
+            }
+        }
 
-        if (false === $return) {
+        if ($deleted !== count($avatarFiles)) {
             $output->writeln('❌ - Failed to clear generated letter avatars.');
 
             return Command::FAILURE;
         }
 
-        $output->writeln("✅  - <comment>$imageCount</comment> letter avatars have been cleared.");
+        $output->writeln(sprintf('✅  - <comment>%d</comment> letter avatars have been cleared.', $deleted));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Guards against a misconfigured image path (e.g. an empty imagePath
+     * resolving to the site root) so recursive avatar deletion cannot touch
+     * unrelated files outside a dedicated avatar directory.
+     */
+    private function isSafeAvatarPath(string $path): bool
+    {
+        $resolvedPath = realpath($path);
+        $resolvedPublicPath = realpath(Environment::getPublicPath());
+
+        return false !== $resolvedPath
+            && false !== $resolvedPublicPath
+            && $resolvedPath !== $resolvedPublicPath;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findAvatarFiles(string $path): array
+    {
+        if (!is_dir($path)) {
+            return [];
+        }
+
+        $files = [];
+        foreach (scandir($path) ?: [] as $entry) {
+            $fullPath = $path.$entry;
+            if (is_file($fullPath) && 1 === preg_match('/\.(png|jpe?g)$/i', $entry)) {
+                $files[] = $fullPath;
+            }
+        }
+
+        return $files;
     }
 }

--- a/Tests/Unit/Command/ClearAvatarsCommandExecuteTest.php
+++ b/Tests/Unit/Command/ClearAvatarsCommandExecuteTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_letter_avatar" TYPO3 CMS extension.
+ *
+ * (c) Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Command;
+
+use KonradMichalik\Typo3LetterAvatar\Command\ClearAvatarsCommand;
+use KonradMichalik\Typo3LetterAvatar\Configuration;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Core\{ApplicationContext, Environment};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function dirname;
+
+/**
+ * ClearAvatarsCommandExecuteTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ClearAvatarsCommandExecuteTest extends TestCase
+{
+    private const IMAGE_PATH = '/.Build/var/tests/clear-avatars/';
+
+    public static function setUpBeforeClass(): void
+    {
+        $extensionRoot = dirname(__DIR__, 3);
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            false,
+            $extensionRoot,
+            $extensionRoot,
+            $extensionRoot.'/.Build/var',
+            $extensionRoot.'/.Build/var/config',
+            $extensionRoot.'/.Build/public/index.php',
+            'UNIX',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'] = '2775';
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [];
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
+            'imagePath' => self::IMAGE_PATH,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::rmdir(Environment::getPublicPath().self::IMAGE_PATH, true);
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'],
+        );
+    }
+
+    #[Test]
+    public function dryRunCountsAvatarsWithoutDeletingThem(): void
+    {
+        $folder = $this->prepareFolderWithFiles();
+
+        $tester = new CommandTester(new ClearAvatarsCommand());
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('2 letter avatars would be cleared', $tester->getDisplay());
+        self::assertFileExists($folder.'avatar-one.png');
+        self::assertFileExists($folder.'avatar-two.jpeg');
+    }
+
+    #[Test]
+    public function executeDeletesOnlyAvatarFiles(): void
+    {
+        $folder = $this->prepareFolderWithFiles();
+
+        $tester = new CommandTester(new ClearAvatarsCommand());
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('2 letter avatars have been cleared', $tester->getDisplay());
+        self::assertFileDoesNotExist($folder.'avatar-one.png');
+        self::assertFileDoesNotExist($folder.'avatar-two.jpeg');
+        // Non-avatar files must survive.
+        self::assertFileExists($folder.'keep.txt');
+        self::assertFileExists($folder.'.gitkeep');
+    }
+
+    #[Test]
+    public function executeRefusesWhenImagePathResolvesToSiteRoot(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration']['imagePath'] = '';
+
+        $tester = new CommandTester(new ClearAvatarsCommand());
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Refusing to clear', $tester->getDisplay());
+    }
+
+    private function prepareFolderWithFiles(): string
+    {
+        $folder = Environment::getPublicPath().self::IMAGE_PATH;
+        GeneralUtility::mkdir_deep($folder);
+
+        file_put_contents($folder.'avatar-one.png', 'png');
+        file_put_contents($folder.'avatar-two.jpeg', 'jpeg');
+        file_put_contents($folder.'keep.txt', 'keep');
+        file_put_contents($folder.'.gitkeep', '');
+
+        return $folder;
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `avatar:clear` recursively removing the **entire** configured image directory via `GeneralUtility::rmdir($path, true)`. A misconfigured `imagePath` (empty string or `/`) resolves to the site root, so the command could wipe the whole public directory.
- Make the dry-run consistent with the real run: previously the dry-run counted only `png/jpg/jpeg` files while the real run deleted the whole folder (including unrelated files).
- The command now deletes only avatar image files and refuses to run when the resolved image path is invalid or equals the site root.

## Changes

- `Classes/Command/ClearAvatarsCommand.php` — replace recursive `rmdir` with per-file deletion of avatar files (`findAvatarFiles`), add a site-root safety guard (`isSafeAvatarPath`), share the file list between dry-run and real deletion.
- `Tests/Unit/Command/ClearAvatarsCommandExecuteTest.php` — new `CommandTester` tests: dry-run deletes nothing, real run deletes only avatars while non-avatar files survive, and execution is refused when the path resolves to the site root.