### PR TITLE
fix: derive avatar filenames from a keyed HMAC to prevent user enumeration

### DIFF
--- a/Classes/Image/AbstractImageProvider.php
+++ b/Classes/Image/AbstractImageProvider.php
@@ -17,8 +17,8 @@ use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\{ColorMode, ImageFormat, Shape, Transform};
 use KonradMichalik\Typo3LetterAvatar\Service\Colorize;
 use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
-use TYPO3\CMS\Core\Crypto\{HashAlgo, HashService};
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function hash_hmac;
 
 /**
  * AbstractImageProvider.
@@ -79,7 +79,8 @@ abstract class AbstractImageProvider
 
         // Keyed HMAC with the site's encryption key so avatar filenames cannot be
         // recomputed from public inputs (e.g. a user's name) to probe their existence.
-        return GeneralUtility::makeInstance(HashService::class)
-            ->hmac(implode('_', $parts), Configuration::EXT_KEY, HashAlgo::SHA256);
+        $secret = (string) ($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] ?? '');
+
+        return hash_hmac('sha256', implode('_', $parts), $secret);
     }
 }

--- a/Classes/Image/AbstractImageProvider.php
+++ b/Classes/Image/AbstractImageProvider.php
@@ -17,6 +17,8 @@ use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\{ColorMode, ImageFormat, Shape, Transform};
 use KonradMichalik\Typo3LetterAvatar\Service\Colorize;
 use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
+use TYPO3\CMS\Core\Crypto\{HashAlgo, HashService};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * AbstractImageProvider.
@@ -75,6 +77,9 @@ abstract class AbstractImageProvider
             $this->shape->value,
         ];
 
-        return hash('sha256', implode('_', $parts));
+        // Keyed HMAC with the site's encryption key so avatar filenames cannot be
+        // recomputed from public inputs (e.g. a user's name) to probe their existence.
+        return GeneralUtility::makeInstance(HashService::class)
+            ->hmac(implode('_', $parts), Configuration::EXT_KEY, HashAlgo::SHA256);
     }
 }

--- a/Tests/Unit/Image/AbstractImageProviderTest.php
+++ b/Tests/Unit/Image/AbstractImageProviderTest.php
@@ -37,6 +37,7 @@ final class AbstractImageProviderTest extends TestCase
     protected function setUp(): void
     {
         // Mock configuration for testing
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key';
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
             'imagePath' => '/typo3temp/assets/avatars/',
         ];
@@ -62,7 +63,10 @@ class(name: 'Test User', size: 100, fontSize: 0.5, mode: ColorMode::CUSTOM, fore
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],
+        );
     }
 
     #[Test]
@@ -114,6 +118,23 @@ class(name: 'Test User', size: 100, fontSize: 0.5, mode: ColorMode::CUSTOM, fore
         self::assertSame($hash1, $hash2);
         self::assertIsString($hash1);
         self::assertNotEmpty($hash1);
+    }
+
+    #[Test]
+    public function configToHashDependsOnEncryptionKey(): void
+    {
+        $reflection = new ReflectionClass($this->imageProvider);
+        $method = $reflection->getMethod('configToHash');
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'first-key';
+        $first = $method->invoke($this->imageProvider);
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'second-key';
+        $second = $method->invoke($this->imageProvider);
+
+        // Identical inputs but a different site secret must not yield the same filename,
+        // otherwise avatar filenames remain computable from public data.
+        self::assertNotSame($first, $second);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Fix avatar filenames being a plain `sha256` over publicly known inputs. With the default configuration every hash component except the name is public, so an unauthenticated visitor could compute the hash for a candidate name and request it from the public avatar directory to confirm whether a backend user with that name (or real name, prioritized by default) exists — a user-enumeration / privacy issue.
- Filenames are now generated via `HashService::hmac()`, keyed with the site's `encryptionKey`, so they can no longer be recomputed from external data.

## Changes

- `Classes/Image/AbstractImageProvider.php` — `configToHash()` uses a keyed HMAC-SHA256 (via TYPO3 `HashService`) instead of a bare `hash('sha256', …)`. Output stays a 64-char hex string, so filename length is unchanged.
- `Tests/Unit/Image/AbstractImageProviderTest.php` — set a stable `encryptionKey` in the fixture and add a test asserting the hash changes when the encryption key changes.

## Note

Existing generated avatars become orphaned after upgrade (their filename changes); they are regenerated on the next request and old files can be removed with `avatar:clear`.