### PR TITLE
perf: cache configuration service and drop per-call reflection

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -15,9 +15,12 @@ namespace KonradMichalik\Typo3LetterAvatar\Utility;
 
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\EnumInterface;
-use ReflectionClass;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function is_int;
+use function is_string;
+use function is_subclass_of;
 
 /**
  * ConfigurationUtility.
@@ -27,30 +30,40 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConfigurationUtility
 {
+    private static ?ExtensionConfiguration $extensionConfiguration = null;
+
     public static function get(string $key, ?string $expectedEnumClass = null): array|string|int|float|bool|EnumInterface|null
     {
-        $configuration = array_merge(
-            GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(Configuration::EXT_KEY),
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] ?? [],
-        );
-
-        $value = $configuration[$key] ?? null;
+        $value = self::getMergedConfiguration()[$key] ?? null;
         if (null === $value) {
             return null;
         }
 
-        if (null !== $expectedEnumClass) {
-            $enumClass = new ReflectionClass($expectedEnumClass);
-            if ($enumClass->isSubclassOf(EnumInterface::class)
-                && $enumClass->isEnum()
-                && !($value instanceof $expectedEnumClass)
-            ) {
-                if (method_exists($expectedEnumClass, 'tryFrom')) {
-                    return $expectedEnumClass::tryFrom($value);
-                }
-            }
+        if (null !== $expectedEnumClass
+            && is_subclass_of($expectedEnumClass, EnumInterface::class)
+            && !($value instanceof $expectedEnumClass)
+            && (is_string($value) || is_int($value))
+        ) {
+            // EnumInterface extends BackedEnum, so tryFrom() is guaranteed here.
+            return $expectedEnumClass::tryFrom($value);
         }
 
         return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function getMergedConfiguration(): array
+    {
+        // The ExtensionConfiguration service is stateless and reads the live
+        // configuration on each call, so caching the instance avoids repeated
+        // service instantiation without ever serving stale configuration.
+        self::$extensionConfiguration ??= GeneralUtility::makeInstance(ExtensionConfiguration::class);
+
+        return array_merge(
+            self::$extensionConfiguration->get(Configuration::EXT_KEY),
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] ?? [],
+        );
     }
 }

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -39,13 +39,13 @@ class ConfigurationUtility
             return null;
         }
 
-        if (null !== $expectedEnumClass
-            && is_subclass_of($expectedEnumClass, EnumInterface::class)
-            && !($value instanceof $expectedEnumClass)
-            && (is_string($value) || is_int($value))
-        ) {
+        if (null !== $expectedEnumClass && is_subclass_of($expectedEnumClass, EnumInterface::class)) {
+            if ($value instanceof $expectedEnumClass) {
+                return $value;
+            }
+
             // EnumInterface extends BackedEnum, so tryFrom() is guaranteed here.
-            return $expectedEnumClass::tryFrom($value);
+            return (is_string($value) || is_int($value)) ? $expectedEnumClass::tryFrom($value) : null;
         }
 
         return $value;

--- a/Tests/CGL/phpstan-baseline.neon
+++ b/Tests/CGL/phpstan-baseline.neon
@@ -229,12 +229,6 @@ parameters:
 			path: ../../Classes/Utility/ConfigurationUtility.php
 
 		-
-			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../Classes/Utility/ConfigurationUtility.php
-
-		-
 			message: '#^Binary operation "\." between string and array\|bool\|float\|int\|KonradMichalik\\Typo3LetterAvatar\\Enum\\EnumInterface\|string\|null results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1

--- a/Tests/Unit/Utility/ConfigurationUtilityTest.php
+++ b/Tests/Unit/Utility/ConfigurationUtilityTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Utility;
 
 use KonradMichalik\Typo3LetterAvatar\Configuration;
+use KonradMichalik\Typo3LetterAvatar\Enum\ColorMode;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +31,7 @@ final class ConfigurationUtilityTest extends TestCase
     protected function setUp(): void
     {
         // Simple TYPO3_CONF_VARS configuration without framework mocking
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [];
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
             'size' => 100,
             'fontSize' => 0.5,
@@ -44,7 +46,10 @@ final class ConfigurationUtilityTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY],
+        );
     }
 
     #[Test]
@@ -76,5 +81,44 @@ final class ConfigurationUtilityTest extends TestCase
         $getMethod = $reflectionClass->getMethod('get');
 
         self::assertTrue($getMethod->isStatic());
+    }
+
+    #[Test]
+    public function getReturnsConfiguredScalarValues(): void
+    {
+        self::assertSame(100, ConfigurationUtility::get('size'));
+        self::assertSame('test-string', ConfigurationUtility::get('stringValue'));
+        self::assertTrue(ConfigurationUtility::get('boolValue'));
+    }
+
+    #[Test]
+    public function getReturnsNullForUnknownKey(): void
+    {
+        self::assertNull(ConfigurationUtility::get('doesNotExist'));
+    }
+
+    #[Test]
+    public function getCastsValueToRequestedEnum(): void
+    {
+        self::assertSame(ColorMode::RANDOM, ConfigurationUtility::get('colorMode', ColorMode::class));
+    }
+
+    #[Test]
+    public function getReturnsNullForInvalidEnumValue(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration']['colorMode'] = 'not-a-mode';
+
+        self::assertNull(ConfigurationUtility::get('colorMode', ColorMode::class));
+    }
+
+    #[Test]
+    public function getReflectsConfigurationChangesImmediately(): void
+    {
+        self::assertSame(100, ConfigurationUtility::get('size'));
+
+        // The live configuration is read on every call, so changes are visible at once.
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration']['size'] = 200;
+
+        self::assertSame(200, ConfigurationUtility::get('size'));
     }
 }


### PR DESCRIPTION
## Summary

- `ConfigurationUtility::get()` allocated a fresh `ReflectionClass` on **every** call (~10× per avatar) and re-instantiated the `ExtensionConfiguration` service each time. The provider calls it many times per avatar, multiplying this over a backend user list.
- The enum resolution now uses `is_subclass_of()` instead of instantiating `ReflectionClass`, and the redundant `method_exists('tryFrom')` check is dropped (`EnumInterface` extends `BackedEnum`, so `tryFrom()` is guaranteed).
- The stateless `ExtensionConfiguration` service instance is cached. The live configuration is still read on **every** call, so no stale configuration is ever served and no cache-reset hook is needed.

> Note: an earlier revision memoized the fully merged configuration array. That was dropped because it served stale configuration when the config changed within a process (which broke sibling test suites) and would have required a test-only `reset()` method. Caching only the stateless service keeps the win without the hazard.

## Changes

- `Classes/Utility/ConfigurationUtility.php` — cache the `ExtensionConfiguration` instance behind `getMergedConfiguration()`, replace reflection with `is_subclass_of()` plus a scalar guard for `tryFrom()`.
- `Tests/Unit/Utility/ConfigurationUtilityTest.php` — functional tests for scalar/enum resolution, unknown keys, invalid enum values, and that configuration changes are reflected immediately.
- `Tests/CGL/phpstan-baseline.neon` — drop the now-obsolete `ReflectionClass` baseline entry.