### PR TITLE
test: integrate ttt for PHPUnit test sandboxing

### DIFF
--- a/Tests/Unit/Image/AbstractImageProviderTest.php
+++ b/Tests/Unit/Image/AbstractImageProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\{ColorMode, ImageFormat, Shape, Transform};
 use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
@@ -30,17 +31,13 @@ use function strlen;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTCONF' => [Configuration::EXT_KEY => ['configuration' => ['imagePath' => '/typo3temp/assets/avatars/']]]])]
 final class AbstractImageProviderTest extends TestCase
 {
     private AbstractImageProvider $imageProvider;
 
     protected function setUp(): void
     {
-        // Mock configuration for testing
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
-            'imagePath' => '/typo3temp/assets/avatars/',
-        ];
-
         // Create anonymous class that extends AbstractImageProvider
         $this->imageProvider = new
 /**
@@ -58,11 +55,6 @@ class(name: 'Test User', size: 100, fontSize: 0.5, mode: ColorMode::CUSTOM, fore
         return '/mock/path/image.png';
     }
 };
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
     }
 
     #[Test]

--- a/Tests/Unit/Image/AvatarTest.php
+++ b/Tests/Unit/Image/AvatarTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Image;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Enum\ImageDriver;
 use KonradMichalik\Typo3LetterAvatar\Image\Avatar;
 use KonradMichalik\Typo3LetterAvatar\Image\Driver\{Gd, Gmagick, Imagick};
@@ -25,14 +26,9 @@ use PHPUnit\Framework\TestCase;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['GFX' => ['processor' => 'ImageMagick']])]
 final class AvatarTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        // Mock TYPO3_CONF_VARS for image driver configuration
-        $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor'] = 'ImageMagick';
-    }
-
     #[Test]
     public function createReturnsImagickDriverByDefault(): void
     {

--- a/Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php
+++ b/Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php
@@ -25,6 +25,12 @@ use function sprintf;
 /**
  * AbstractRenderingTestCase.
  *
+ * The TYPO3 Environment must be initialized with the extension root as project
+ * path so the drivers' absolute font path (inside Resources/) passes
+ * GeneralUtility::getFileAbsFileName()'s isAllowedAbsPath() check. ttt's
+ * #[WithEnvironment] deliberately uses a temporary project directory, which
+ * would place the font outside the allowed path — hence this stays hand-rolled.
+ *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */

--- a/Tests/Unit/Service/BackendThemeResolverTest.php
+++ b/Tests/Unit/Service/BackendThemeResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Service;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Service\BackendThemeResolver;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,32 +25,26 @@ use PHPUnit\Framework\TestCase;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTCONF' => [Configuration::EXT_KEY => ['configuration' => [
+    'backendThemes' => [
+        // theme-specific (primary axis)
+        'modern' => 'backend-modern',
+        'fresh' => 'backend-fresh',
+        'classic' => 'backend-classic',
+        // scheme fallback (only used when theme is unknown)
+        'light' => 'grayscale-light',
+        'dark' => 'grayscale-dark',
+        'auto' => 'grayscale-light',
+        'default' => 'backend-modern',
+    ],
+]]]])]
 final class BackendThemeResolverTest extends TestCase
 {
     private BackendThemeResolver $resolver;
 
     protected function setUp(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
-            'backendThemes' => [
-                // theme-specific (primary axis)
-                'modern' => 'backend-modern',
-                'fresh' => 'backend-fresh',
-                'classic' => 'backend-classic',
-                // scheme fallback (only used when theme is unknown)
-                'light' => 'grayscale-light',
-                'dark' => 'grayscale-dark',
-                'auto' => 'grayscale-light',
-                'default' => 'backend-modern',
-            ],
-        ];
-
         $this->resolver = new BackendThemeResolver();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
     }
 
     #[Test]

--- a/Tests/Unit/Service/ColorizeTest.php
+++ b/Tests/Unit/Service/ColorizeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Service;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Enum\ColorMode;
 use KonradMichalik\Typo3LetterAvatar\Image\AbstractImageProvider;
@@ -28,6 +29,32 @@ use function count;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTCONF' => [Configuration::EXT_KEY => ['configuration' => [
+    'random' => [
+        'foregrounds' => ['#FFFFFF', '#000000'],
+        'backgrounds' => ['#FF0000', '#00FF00', '#0000FF'],
+    ],
+    'pairs' => [
+        [
+            'foreground' => '#FFFFFF',
+            'background' => '#000000',
+        ],
+        [
+            'foreground' => '#000000',
+            'background' => '#FFFFFF',
+        ],
+    ],
+    'themes' => [
+        'test-theme' => [
+            'foregrounds' => ['#CCCCCC'],
+            'backgrounds' => ['#333333'],
+        ],
+        'multi-theme' => [
+            'foregrounds' => ['#AAA', '#BBB'],
+            'backgrounds' => ['#111', '#222'],
+        ],
+    ],
+]]]])]
 final class ColorizeTest extends TestCase
 {
     private AbstractImageProvider $avatarProvider;
@@ -35,41 +62,8 @@ final class ColorizeTest extends TestCase
 
     protected function setUp(): void
     {
-        // Set up mock configuration for testing
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
-            'random' => [
-                'foregrounds' => ['#FFFFFF', '#000000'],
-                'backgrounds' => ['#FF0000', '#00FF00', '#0000FF'],
-            ],
-            'pairs' => [
-                [
-                    'foreground' => '#FFFFFF',
-                    'background' => '#000000',
-                ],
-                [
-                    'foreground' => '#000000',
-                    'background' => '#FFFFFF',
-                ],
-            ],
-            'themes' => [
-                'test-theme' => [
-                    'foregrounds' => ['#CCCCCC'],
-                    'backgrounds' => ['#333333'],
-                ],
-                'multi-theme' => [
-                    'foregrounds' => ['#AAA', '#BBB'],
-                    'backgrounds' => ['#111', '#222'],
-                ],
-            ],
-        ];
-
         $this->avatarProvider = $this->createMock(AbstractImageProvider::class);
         $this->colorizeService = new Colorize($this->avatarProvider);
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
     }
 
     #[Test]

--- a/Tests/Unit/Utility/ConfigurationUtilityTest.php
+++ b/Tests/Unit/Utility/ConfigurationUtilityTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Utility;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Utility\ConfigurationUtility;
 use PHPUnit\Framework\Attributes\Test;
@@ -25,28 +26,18 @@ use ReflectionClass;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTCONF' => [Configuration::EXT_KEY => ['configuration' => [
+    'size' => 100,
+    'fontSize' => 0.5,
+    'colorMode' => 'random',
+    'imageFormat' => 'png',
+    'stringValue' => 'test-string',
+    'intValue' => 42,
+    'floatValue' => 3.14,
+    'boolValue' => true,
+]]]])]
 final class ConfigurationUtilityTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        // Simple TYPO3_CONF_VARS configuration without framework mocking
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
-            'size' => 100,
-            'fontSize' => 0.5,
-            'colorMode' => 'random',
-            'imageFormat' => 'png',
-            'stringValue' => 'test-string',
-            'intValue' => 42,
-            'floatValue' => 3.14,
-            'boolValue' => true,
-        ];
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
-    }
-
     #[Test]
     public function getMethodExists(): void
     {

--- a/Tests/Unit/Utility/PathUtilityTest.php
+++ b/Tests/Unit/Utility/PathUtilityTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3LetterAvatar\Tests\Unit\Utility;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use KonradMichalik\Typo3LetterAvatar\Configuration;
 use KonradMichalik\Typo3LetterAvatar\Utility\PathUtility;
 use PHPUnit\Framework\Attributes\Test;
@@ -28,24 +29,15 @@ use function defined;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTCONF' => [Configuration::EXT_KEY => ['configuration' => ['imagePath' => '/typo3temp/assets/avatars/']]]])]
 final class PathUtilityTest extends TestCase
 {
     protected function setUp(): void
     {
-        // Mock TYPO3 configuration
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['configuration'] = [
-            'imagePath' => '/typo3temp/assets/avatars/',
-        ];
-
-        // Mock TYPO3 Environment
+        // Mock TYPO3 Environment (constants cannot be sandboxed via attributes)
         if (!defined('TYPO3_PATH_ROOT')) {
             define('TYPO3_PATH_ROOT', '/var/www/html');
         }
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
     }
 
     #[Test]

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"eliashaeussler/typo3-vendor-bundler": "^4.0.3",
 		"eliashaeussler/version-bumper": "^4.0.3",
 		"helhum/typo3-console": "^9.0.0",
+		"konradmichalik/ttt": "^0.2.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
 		"symfony/translation": "^7.0 || ^8.0",
 		"typo3/cms-base-distribution": "^13.4 || ^14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8600eb7090ee41b936853acc0a1a9a9",
+    "content-hash": "37a16ea98d1527716067276ce0d4c768",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5895,6 +5895,71 @@
             "time": "2026-05-19T11:25:15+00:00"
         },
         {
+            "name": "konradmichalik/ttt",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/konradmichalik/ttt.git",
+                "reference": "7924d932009d8a20b9b4e12e67bf4baf28dd0057"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/konradmichalik/ttt/zipball/7924d932009d8a20b9b4e12e67bf4baf28dd0057",
+                "reference": "7924d932009d8a20b9b4e12e67bf4baf28dd0057",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^2.0",
+                "ergebnis/composer-normalize": "^2.44",
+                "konradmichalik/php-cs-fixer-preset": "^0.2.0",
+                "konradmichalik/php-doc-block-header-fixer": "^0.3.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "rector/rector": "^2.2",
+                "typo3/cms-core": "^13.4 || ^14.0"
+            },
+            "suggest": {
+                "typo3/cms-core": "Required for TYPO3-specific attributes like InApplicationContext and WithEnvironment (^13.4 || ^14.0)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "KonradMichalik\\Ttt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Konrad Michalik",
+                    "email": "hej@konradmichalik.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "ttt - TYPO3 Testing Terrarium. Declarative test sandboxing via PHP attributes: TYPO3_CONF_VARS, application context, environment and more - applied before the test, guaranteed to be restored afterwards.",
+            "keywords": [
+                "Toolbox",
+                "attributes",
+                "php",
+                "phpunit",
+                "sandbox",
+                "testing",
+                "ttt",
+                "typo3"
+            ],
+            "support": {
+                "issues": "https://github.com/konradmichalik/ttt/issues",
+                "source": "https://github.com/konradmichalik/ttt/tree/0.2.0"
+            },
+            "time": "2026-07-27T11:34:34+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -10272,5 +10337,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <extensions>
+        <bootstrap class="KonradMichalik\Ttt\TttExtension"/>
+    </extensions>
     <php>
         <env name="COLUMNS" value="300" />
     </php>


### PR DESCRIPTION
## Summary
- Integrate [`konradmichalik/ttt`](https://github.com/konradmichalik/ttt) (TYPO3 Testing Terrarium) as the unit-test sandbox and register its PHPUnit extension.
- Replace hand-written `$GLOBALS['TYPO3_CONF_VARS']` `setUp()`/`tearDown()` boilerplate with the declarative `#[WithTypo3ConfVars]` attribute in six unit tests. Restoration is now guaranteed by PHPUnit's event system regardless of test outcome.
- Full unit suite stays green with unchanged coverage (149 tests, 279 assertions, 10 skipped; lines 52.81%, methods 54.10%, classes 28.57% — identical before/after).

## Changes
- `composer.json` / `composer.lock` - add `konradmichalik/ttt` (`^0.2.0`) as a dev dependency.
- `phpunit.xml` - register `KonradMichalik\Ttt\TttExtension` (unit config only).
- `Tests/Unit/Utility/ConfigurationUtilityTest.php` - config block moved to class-level `#[WithTypo3ConfVars]`; `setUp`/`tearDown` removed.
- `Tests/Unit/Utility/PathUtilityTest.php` - CONF_VARS moved to attribute; `setUp` kept only for the `TYPO3_PATH_ROOT` constant (constants can't be sandboxed by attributes); `tearDown` removed.
- `Tests/Unit/Image/AvatarTest.php` - `GFX.processor` baseline moved to `#[WithTypo3ConfVars]`; also fixes a pre-existing leak (old `setUp` had no matching `tearDown`).
- `Tests/Unit/Image/AbstractImageProviderTest.php` - CONF_VARS moved to attribute; `setUp` kept for anonymous-class construction; `tearDown` removed.
- `Tests/Unit/Service/BackendThemeResolverTest.php` - CONF_VARS baseline moved to attribute; `setUp` kept for resolver construction; mid-test overrides retained; `tearDown` removed.
- `Tests/Unit/Service/ColorizeTest.php` - CONF_VARS moved to attribute; `setUp` kept for mock/service; `tearDown` removed.
- `Tests/Unit/Image/Rendering/AbstractRenderingTestCase.php` - documents why `Environment::initialize` stays hand-rolled: `#[WithEnvironment]` uses a temporary project path, pushing the extension's absolute font path outside `isAllowedAbsPath()` and breaking `GeneralUtility::getFileAbsFileName()`.

## Notes
- `ImageFixtures::createPng()` has no genuine target here: the only image decode (`GmagickRenderingTest`) round-trips a real Gmagick-produced PNG blob, not a hand-built fixture. No repo-local helper traits existed to delete.
- ttt requires PHP >= 8.2; the CI matrix is PHP 8.2-8.5, so the whole matrix is compatible.

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test configuration for more consistent and isolated test runs.
  * Streamlined test setup and cleanup, reducing manual configuration handling.
  * Added coverage for extension-specific settings and environment initialization.

* **Documentation**
  * Clarified environment initialization behavior and path validation requirements in image-rendering tests.

* **Chores**
  * Updated the test framework configuration to support the standardized test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->